### PR TITLE
Add AllPrimitives and AllPrimitivesWithKeyManager

### DIFF
--- a/core/primitiveset/primitiveset.go
+++ b/core/primitiveset/primitiveset.go
@@ -108,9 +108,9 @@ func (ps *PrimitiveSet) Add(primitive interface{}, key *tinkpb.Keyset_Key) (*Ent
 	if key.GetKeyData() == nil {
 		return nil, fmt.Errorf("primitive_set: keyData must not be nil")
 	}
-	if key.GetStatus() != tinkpb.KeyStatusType_ENABLED {
-		return nil, fmt.Errorf("primitive_set: The key must be ENABLED")
-	}
+	// if key.GetStatus() != tinkpb.KeyStatusType_ENABLED {
+	// 	return nil, fmt.Errorf("primitive_set: The key must be ENABLED")
+	// }
 	prefix, err := cryptofmt.OutputPrefix(key)
 	if err != nil {
 		return nil, fmt.Errorf("primitive_set: %s", err)

--- a/core/primitiveset/primitiveset_test.go
+++ b/core/primitiveset/primitiveset_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tink-crypto/tink-go/v2/core/primitiveset"
-	"github.com/tink-crypto/tink-go/v2/testutil"
 	tinkpb "github.com/tink-crypto/tink-go/v2/proto/tink_go_proto"
+	"github.com/tink-crypto/tink-go/v2/testutil"
 )
 
 func makeTestKey(keyID int, status tinkpb.KeyStatusType, outputPrefixType tinkpb.OutputPrefixType, typeURL string) *tinkpb.Keyset_Key {
@@ -261,11 +261,11 @@ func TestAddWithInvalidInput(t *testing.T) {
 			primitive: &testutil.DummyMAC{},
 			key:       makeTestKey(0, tinkpb.KeyStatusType_ENABLED, tinkpb.OutputPrefixType_UNKNOWN_PREFIX, "type.url.1"),
 		},
-		{
-			tag:       "disabled key",
-			primitive: &testutil.DummyMAC{},
-			key:       makeTestKey(0, tinkpb.KeyStatusType_DISABLED, tinkpb.OutputPrefixType_TINK, "type.url.1"),
-		},
+		// {
+		// 	tag:       "disabled key",
+		// 	primitive: &testutil.DummyMAC{},
+		// 	key:       makeTestKey(0, tinkpb.KeyStatusType_DISABLED, tinkpb.OutputPrefixType_TINK, "type.url.1"),
+		// },
 		{
 			tag:       "nil keyData",
 			primitive: &testutil.DummyMAC{},


### PR DESCRIPTION
These new methods on the keyset handle complement `Primitives` and `PrimitivesWithKeyManager`, but return all primitives, not just enabled primitives. This can be useful for key implementations to display information about key parameters, but should not be used to create sets for encryption duties, since only enabled keys should be used for encryption.

Done by adding a filter function to the private `primitives` method, and having `Primitives` and `PrimitivesWithKeyManager` use it to filter for enabled keys, while `AllPrimitives` and `AllPrimitivesWithKeyManager` don't filter. This keeps the code changes to a minimum. Also: add test to ensure that disabled keys are included in the `All` methods but excluded in the non-`All` methods.

Requires disabling the check for enabled keys in `primitiveset`; should probably change it to allow the adding of other keys through a separate method or something, but I wanted to get some feedback and discussion going before I dove into that, so simply commenting out that check (and the corresponding test) for now.

See discussion in #14 for some of the background on this proposal.