### PR TITLE
streamingaead: add NewDecryptingReaderAt for random-access decryption

### DIFF
--- a/streamingaead/decrypt_reader_at.go
+++ b/streamingaead/decrypt_reader_at.go
@@ -1,0 +1,170 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package streamingaead
+
+import (
+	"fmt"
+	"io"
+	"sync/atomic"
+
+	"github.com/tink-crypto/tink-go/v2/internal/factoryutil"
+	"github.com/tink-crypto/tink-go/v2/internal/registryconfig"
+	"github.com/tink-crypto/tink-go/v2/keyset"
+	"github.com/tink-crypto/tink-go/v2/streamingaead/subtle/noncebased"
+	"github.com/tink-crypto/tink-go/v2/tink"
+)
+
+// SizedReaderAt combines io.ReaderAt with a Size method reporting the total
+// number of bytes available. *bytes.Reader and *io.SectionReader implement this
+// interface.
+type SizedReaderAt interface {
+	io.ReaderAt
+	Size() int64
+}
+
+// readerAtAEAD is implemented by streaming AEAD primitives that support
+// random-access decryption.
+type readerAtAEAD interface {
+	NewDecryptingReaderAt(ct io.ReaderAt, ctSize int64, aad []byte) (*noncebased.ReaderAt, error)
+	HeaderLength() int
+}
+
+type readerAtCandidate struct {
+	r      *noncebased.ReaderAt
+	hdrLen int
+}
+
+// DecryptingReaderAt provides random access to the plaintext of a streaming
+// AEAD ciphertext.
+//
+// It satisfies io.ReaderAt and is safe for concurrent use; ReadAt calls execute
+// in parallel. A single decrypted ciphertext segment is cached, so sequential
+// reads within one segment do not repeat decryption.
+type DecryptingReaderAt struct {
+	candidates []readerAtCandidate
+	matched    atomic.Pointer[readerAtCandidate]
+}
+
+var _ io.ReaderAt = (*DecryptingReaderAt)(nil)
+
+// NewDecryptingReaderAt returns a DecryptingReaderAt that decrypts the
+// ciphertext available via ct using the keys in handle and aad as associated
+// authenticated data.
+//
+// The ciphertext header is read eagerly during construction. For keysets
+// containing multiple keys, the correct key is identified lazily on the first
+// ReadAt call: each candidate key is tried in keyset order until one
+// authenticates the requested segment.
+//
+// ct must provide the full ciphertext stream as written by an encrypting
+// writer obtained from New, and ct.Size() must return its exact length.
+func NewDecryptingReaderAt(handle *keyset.Handle, ct SizedReaderAt, aad []byte) (*DecryptingReaderAt, error) {
+	if handle.Len() == 0 {
+		return nil, fmt.Errorf("streamingaead: empty or nil keyset handle")
+	}
+	config := &registryconfig.RegistryConfig{}
+
+	ctSize := ct.Size()
+	var candidates []readerAtCandidate
+	for entry := range factoryutil.EnabledUnmonitoredEntries(handle) {
+		// Streaming AEAD primitives are always without output prefix, so the
+		// boolean indicating a legacy "non-full" primitive is ignored.
+		primitive, _, err := factoryutil.PrimitiveFromKey[tink.StreamingAEAD](entry.Key(), config)
+		if err != nil {
+			return nil, err
+		}
+		ra, ok := primitive.(readerAtAEAD)
+		if !ok {
+			continue
+		}
+		r, err := ra.NewDecryptingReaderAt(ct, ctSize, aad)
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, readerAtCandidate{r: r, hdrLen: ra.HeaderLength()})
+	}
+	if len(candidates) == 0 {
+		return nil, errKeyNotFound
+	}
+	return &DecryptingReaderAt{candidates: candidates}, nil
+}
+
+// ReadAt decrypts and returns plaintext bytes at the given offset.
+func (d *DecryptingReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if len(p) == 0 {
+		// A zero-length read decrypts nothing, so it cannot tell the
+		// candidate keys apart. Answering it directly keeps it from
+		// selecting one at random.
+		return 0, nil
+	}
+	if c := d.matched.Load(); c != nil {
+		return c.r.ReadAt(p, off)
+	}
+	for i := range d.candidates {
+		// A candidate that reports io.EOF has decrypted the final segment,
+		// which only the encrypting key can do, so it is as conclusive a
+		// match as a successful read.
+		n, err := d.candidates[i].r.ReadAt(p, off)
+		if err == nil || err == io.EOF {
+			d.matched.Store(&d.candidates[i])
+			return n, err
+		}
+	}
+	return 0, errKeyNotFound
+}
+
+// selected returns the matched candidate once known, otherwise the first
+// candidate.
+func (d *DecryptingReaderAt) selected() *readerAtCandidate {
+	if c := d.matched.Load(); c != nil {
+		return c
+	}
+	return &d.candidates[0]
+}
+
+// Size returns the size of the plaintext.
+//
+// The returned value is derived from the length of the ciphertext, which is
+// not itself authenticated: a truncated stream yields a smaller size. A read
+// that reaches the end of the plaintext decrypts the final segment and so
+// fails on a truncated stream, which makes reading the whole plaintext, or a
+// single byte at Size()-1, sufficient to establish that the size is genuine.
+//
+// For keysets containing multiple keys, the value reported before the first
+// ReadAt is computed from the first candidate key's parameters.
+func (d *DecryptingReaderAt) Size() int64 {
+	return d.selected().r.Size()
+}
+
+// CiphertextRange returns the byte range [off, off+n) within the ciphertext
+// passed to NewDecryptingReaderAt that ReadAt will access in order to satisfy a
+// plaintext read of [ptOff, ptOff+ptLen). Callers backed by remote storage can
+// use this to prefetch the required bytes in a single round trip.
+//
+// The returned range covers whole ciphertext segments and does not include the
+// stream header (which has already been read at construction time). For keysets
+// containing keys with heterogeneous segment-size or header-length parameters,
+// the value reported before the first successful ReadAt is computed from the
+// first candidate key's parameters and may not match the encrypting key's
+// layout; in that case, perform a single small ReadAt first to lock in the
+// correct key.
+func (d *DecryptingReaderAt) CiphertextRange(ptOff, ptLen int64) (off, n int64) {
+	c := d.selected()
+	off, n = c.r.CiphertextRange(ptOff, ptLen)
+	if n == 0 {
+		return 0, 0
+	}
+	return off + int64(c.hdrLen), n
+}

--- a/streamingaead/decrypt_reader_at_test.go
+++ b/streamingaead/decrypt_reader_at_test.go
@@ -1,0 +1,380 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package streamingaead_test
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/tink-crypto/tink-go/v2/keyset"
+	tinkpb "github.com/tink-crypto/tink-go/v2/proto/tink_go_proto"
+	"github.com/tink-crypto/tink-go/v2/streamingaead"
+	"github.com/tink-crypto/tink-go/v2/subtle/random"
+	"github.com/tink-crypto/tink-go/v2/testkeyset"
+	"github.com/tink-crypto/tink-go/v2/testutil"
+)
+
+func encryptForReaderAt(t *testing.T, handle *keyset.Handle, ptSize int) ([]byte, []byte, []byte) {
+	t.Helper()
+	pt := random.GetRandomBytes(uint32(ptSize))
+	aad := random.GetRandomBytes(32)
+	a, err := streamingaead.New(handle)
+	if err != nil {
+		t.Fatalf("streamingaead.New: %v", err)
+	}
+	var buf bytes.Buffer
+	w, err := a.NewEncryptingWriter(&buf, aad)
+	if err != nil {
+		t.Fatalf("NewEncryptingWriter: %v", err)
+	}
+	if _, err := w.Write(pt); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return pt, buf.Bytes(), aad
+}
+
+func TestNewDecryptingReaderAtSingleKey(t *testing.T) {
+	templates := []struct {
+		name     string
+		template *tinkpb.KeyTemplate
+	}{
+		{"AES128GCMHKDF4KB", streamingaead.AES128GCMHKDF4KBKeyTemplate()},
+		{"AES256GCMHKDF1MB", streamingaead.AES256GCMHKDF1MBKeyTemplate()},
+		{"AES128CTRHMACSHA256Segment4KB", streamingaead.AES128CTRHMACSHA256Segment4KBKeyTemplate()},
+	}
+	for _, tmpl := range templates {
+		t.Run(tmpl.name, func(t *testing.T) {
+			handle, err := keyset.NewHandle(tmpl.template)
+			if err != nil {
+				t.Fatalf("keyset.NewHandle: %v", err)
+			}
+			for _, ptSize := range []int{0, 100, 4095, 4096, 4097, 20000} {
+				pt, ct, aad := encryptForReaderAt(t, handle, ptSize)
+				r, err := streamingaead.NewDecryptingReaderAt(handle, bytes.NewReader(ct), aad)
+				if err != nil {
+					t.Fatalf("NewDecryptingReaderAt(%d): %v", ptSize, err)
+				}
+				if got := r.Size(); got != int64(ptSize) {
+					t.Errorf("Size() = %d, want %d", got, ptSize)
+				}
+				got := make([]byte, ptSize)
+				if n, err := r.ReadAt(got, 0); n != ptSize || (err != nil && err != io.EOF) {
+					t.Fatalf("ReadAt(0) = %d, %v; want %d, nil", n, err, ptSize)
+				}
+				if !bytes.Equal(got, pt) {
+					t.Errorf("plaintext mismatch (size %d)", ptSize)
+				}
+			}
+		})
+	}
+}
+
+func TestDecryptingReaderAtConcurrent(t *testing.T) {
+	templates := []struct {
+		name     string
+		template *tinkpb.KeyTemplate
+	}{
+		{"AES128GCMHKDF4KB", streamingaead.AES128GCMHKDF4KBKeyTemplate()},
+		{"AES128CTRHMACSHA256Segment4KB", streamingaead.AES128CTRHMACSHA256Segment4KBKeyTemplate()},
+	}
+	for _, tmpl := range templates {
+		t.Run(tmpl.name, func(t *testing.T) {
+			handle, err := keyset.NewHandle(tmpl.template)
+			if err != nil {
+				t.Fatalf("keyset.NewHandle: %v", err)
+			}
+			pt, ct, aad := encryptForReaderAt(t, handle, 32*1024)
+			r, err := streamingaead.NewDecryptingReaderAt(handle, bytes.NewReader(ct), aad)
+			if err != nil {
+				t.Fatalf("NewDecryptingReaderAt: %v", err)
+			}
+			var wg sync.WaitGroup
+			for g := 0; g < 8; g++ {
+				wg.Add(1)
+				go func(seed int64) {
+					defer wg.Done()
+					rng := rand.New(rand.NewSource(seed))
+					for i := 0; i < 50; i++ {
+						off := rng.Int63n(int64(len(pt)))
+						l := rng.Intn(256) + 1
+						buf := make([]byte, l)
+						n, err := r.ReadAt(buf, off)
+						end := int(off) + l
+						if end > len(pt) {
+							end = len(pt)
+						}
+						if n != end-int(off) || !bytes.Equal(buf[:n], pt[off:end]) {
+							t.Errorf("mismatch at off=%d (err=%v)", off, err)
+							return
+						}
+					}
+				}(int64(g))
+			}
+			wg.Wait()
+		})
+	}
+}
+
+func TestNewDecryptingReaderAtMultipleKeys(t *testing.T) {
+	ks := testutil.NewTestAESGCMHKDFKeyset()
+	handle, err := testkeyset.NewHandle(ks)
+	if err != nil {
+		t.Fatalf("testkeyset.NewHandle: %v", err)
+	}
+
+	t.Run("encryptWithPrimary", func(t *testing.T) {
+		pt, ct, aad := encryptForReaderAt(t, handle, 5000)
+		r, err := streamingaead.NewDecryptingReaderAt(handle, bytes.NewReader(ct), aad)
+		if err != nil {
+			t.Fatalf("NewDecryptingReaderAt: %v", err)
+		}
+		got := make([]byte, len(pt))
+		if _, err := r.ReadAt(got, 0); err != nil && err != io.EOF {
+			t.Fatalf("ReadAt: %v", err)
+		}
+		if !bytes.Equal(got, pt) {
+			t.Error("plaintext mismatch")
+		}
+	})
+
+	t.Run("encryptWithNonPrimary", func(t *testing.T) {
+		rawKey := ks.Key[1]
+		ks2 := testutil.NewKeyset(rawKey.KeyId, []*tinkpb.Keyset_Key{rawKey})
+		handle2, err := testkeyset.NewHandle(ks2)
+		if err != nil {
+			t.Fatalf("testkeyset.NewHandle: %v", err)
+		}
+		pt, ct, aad := encryptForReaderAt(t, handle2, 5000)
+		// Decrypt with the full keyset; should find the right key.
+		r, err := streamingaead.NewDecryptingReaderAt(handle, bytes.NewReader(ct), aad)
+		if err != nil {
+			t.Fatalf("NewDecryptingReaderAt: %v", err)
+		}
+		got := make([]byte, len(pt))
+		if _, err := r.ReadAt(got, 0); err != nil && err != io.EOF {
+			t.Fatalf("ReadAt: %v", err)
+		}
+		if !bytes.Equal(got, pt) {
+			t.Error("plaintext mismatch")
+		}
+		// Subsequent reads use the matched key.
+		buf := make([]byte, 100)
+		if _, err := r.ReadAt(buf, 1000); err != nil {
+			t.Errorf("second ReadAt: %v", err)
+		}
+		if !bytes.Equal(buf, pt[1000:1100]) {
+			t.Error("second read mismatch")
+		}
+	})
+
+	t.Run("readThatDecryptsNothingDoesNotSelectAKey", func(t *testing.T) {
+		// A read returning no plaintext cannot tell the candidate keys apart,
+		// so it must not select one; otherwise it would pin the wrong key and
+		// every later read would fail. The two keys must be distinct but
+		// share their parameters, so that both survive the header check and
+		// the wrong one is only ruled out by decrypting.
+		first, err := keyset.NewHandle(streamingaead.AES256GCMHKDF4KBKeyTemplate())
+		if err != nil {
+			t.Fatalf("keyset.NewHandle: %v", err)
+		}
+		mgr := keyset.NewManagerFromHandle(first)
+		id, err := mgr.Add(streamingaead.AES256GCMHKDF4KBKeyTemplate())
+		if err != nil {
+			t.Fatalf("Manager.Add: %v", err)
+		}
+		if err := mgr.SetPrimary(id); err != nil {
+			t.Fatalf("Manager.SetPrimary: %v", err)
+		}
+		rotated, err := mgr.Handle()
+		if err != nil {
+			t.Fatalf("Manager.Handle: %v", err)
+		}
+		pt, ct, aad := encryptForReaderAt(t, rotated, 5000)
+
+		for _, probe := range []struct {
+			name string
+			p    []byte
+			off  int64
+		}{
+			{"zeroLengthRead", nil, 0},
+			{"readPastEndOfPlaintext", make([]byte, 1), int64(len(pt)) + 1},
+		} {
+			t.Run(probe.name, func(t *testing.T) {
+				r, err := streamingaead.NewDecryptingReaderAt(rotated, bytes.NewReader(ct), aad)
+				if err != nil {
+					t.Fatalf("NewDecryptingReaderAt: %v", err)
+				}
+				if _, err := r.ReadAt(probe.p, probe.off); err != nil && err != io.EOF {
+					t.Fatalf("probe ReadAt: %v", err)
+				}
+				got := make([]byte, len(pt))
+				if _, err := r.ReadAt(got, 0); err != nil && err != io.EOF {
+					t.Fatalf("ReadAt after probe: %v", err)
+				}
+				if !bytes.Equal(got, pt) {
+					t.Error("plaintext mismatch after probe")
+				}
+			})
+		}
+	})
+
+	t.Run("noMatchingKey", func(t *testing.T) {
+		other := testutil.NewTestAESGCMHKDFKeyset()
+		otherHandle, err := testkeyset.NewHandle(other)
+		if err != nil {
+			t.Fatalf("testkeyset.NewHandle: %v", err)
+		}
+		_, ct, aad := encryptForReaderAt(t, otherHandle, 1000)
+		r, err := streamingaead.NewDecryptingReaderAt(handle, bytes.NewReader(ct), aad)
+		if err != nil {
+			t.Fatalf("NewDecryptingReaderAt: %v", err)
+		}
+		buf := make([]byte, 10)
+		if _, err := r.ReadAt(buf, 0); err == nil {
+			t.Error("ReadAt with wrong keyset succeeded, want error")
+		}
+	})
+}
+
+func TestDecryptingReaderAtCiphertextRange(t *testing.T) {
+	handle, err := keyset.NewHandle(streamingaead.AES128GCMHKDF4KBKeyTemplate())
+	if err != nil {
+		t.Fatalf("keyset.NewHandle: %v", err)
+	}
+	pt, ct, aad := encryptForReaderAt(t, handle, 20000)
+	r, err := streamingaead.NewDecryptingReaderAt(handle, bytes.NewReader(ct), aad)
+	if err != nil {
+		t.Fatalf("NewDecryptingReaderAt: %v", err)
+	}
+
+	// CiphertextRange must cover bytes sufficient to satisfy the read; verify by
+	// decrypting using only that range.
+	off, n := r.CiphertextRange(5000, 1000)
+	if off <= 0 || n <= 0 || off+n > int64(len(ct)) {
+		t.Fatalf("CiphertextRange = [%d,%d), out of bounds [0,%d)", off, off+n, len(ct))
+	}
+	// Supply only the header, which is read at construction time, and the
+	// reported range. Everything else stays zero, so the read fails if the
+	// range is too narrow at either end.
+	headerLen := int64(ct[0])
+	if off < headerLen {
+		t.Fatalf("CiphertextRange offset %d overlaps the %d-byte header", off, headerLen)
+	}
+	partial := make([]byte, len(ct))
+	copy(partial[:headerLen], ct[:headerLen])
+	copy(partial[off:off+n], ct[off:off+n])
+	r2, err := streamingaead.NewDecryptingReaderAt(handle, bytes.NewReader(partial), aad)
+	if err != nil {
+		t.Fatalf("NewDecryptingReaderAt(partial): %v", err)
+	}
+	buf := make([]byte, 1000)
+	if _, err := r2.ReadAt(buf, 5000); err != nil {
+		t.Fatalf("ReadAt(partial): %v", err)
+	}
+	if !bytes.Equal(buf, pt[5000:6000]) {
+		t.Error("partial-range read mismatch")
+	}
+}
+
+func TestDecryptingReaderAtWithSectionReader(t *testing.T) {
+	handle, err := keyset.NewHandle(streamingaead.AES128GCMHKDF4KBKeyTemplate())
+	if err != nil {
+		t.Fatalf("keyset.NewHandle: %v", err)
+	}
+	pt, ct, aad := encryptForReaderAt(t, handle, 1000)
+	sr := io.NewSectionReader(bytes.NewReader(ct), 0, int64(len(ct)))
+	r, err := streamingaead.NewDecryptingReaderAt(handle, sr, aad)
+	if err != nil {
+		t.Fatalf("NewDecryptingReaderAt: %v", err)
+	}
+	got := make([]byte, len(pt))
+	if _, err := r.ReadAt(got, 0); err != nil && err != io.EOF {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(got, pt) {
+		t.Error("plaintext mismatch")
+	}
+}
+
+// wrongSizeReaderAt reports a deliberately incorrect Size while delegating
+// ReadAt to the underlying reader.
+type wrongSizeReaderAt struct {
+	io.ReaderAt
+	size int64
+}
+
+func (w wrongSizeReaderAt) Size() int64 { return w.size }
+
+func TestDecryptingReaderAtWrongSize(t *testing.T) {
+	handle, err := keyset.NewHandle(streamingaead.AES128GCMHKDF4KBKeyTemplate())
+	if err != nil {
+		t.Fatalf("keyset.NewHandle: %v", err)
+	}
+	pt, ct, aad := encryptForReaderAt(t, handle, 10000)
+	for _, tc := range []struct {
+		name  string
+		delta int64
+	}{
+		{"minus1", -1},
+		{"minusSegment", -4096},
+		{"plus1", 1},
+		{"plusSegment", 4096},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := wrongSizeReaderAt{ReaderAt: bytes.NewReader(ct), size: int64(len(ct)) + tc.delta}
+			r, err := streamingaead.NewDecryptingReaderAt(handle, src, aad)
+			if err != nil {
+				// Construction may legitimately reject some sizes.
+				return
+			}
+			// A read in the first segment must either fail or return correct
+			// bytes; an incorrect size must not cause silent corruption.
+			buf := make([]byte, 16)
+			if n, err := r.ReadAt(buf, 0); err == nil {
+				if !bytes.Equal(buf[:n], pt[:n]) {
+					t.Fatalf("ReadAt(0) returned corrupted plaintext")
+				}
+			}
+			// A read covering the final segment must fail: the wrong size
+			// changes either the last-segment nonce flag or the segment
+			// boundaries, so authentication of the affected segment must fail.
+			if _, err := r.ReadAt(buf, int64(len(pt))-16); err == nil {
+				t.Errorf("ReadAt near end with wrong size %+d succeeded, want error", tc.delta)
+			}
+		})
+	}
+}
+
+func TestDecryptingReaderAtBadAAD(t *testing.T) {
+	handle, err := keyset.NewHandle(streamingaead.AES128GCMHKDF4KBKeyTemplate())
+	if err != nil {
+		t.Fatalf("keyset.NewHandle: %v", err)
+	}
+	_, ct, _ := encryptForReaderAt(t, handle, 1000)
+	r, err := streamingaead.NewDecryptingReaderAt(handle, bytes.NewReader(ct), []byte("wrong"))
+	if err != nil {
+		t.Fatalf("NewDecryptingReaderAt: %v", err)
+	}
+	buf := make([]byte, 10)
+	if _, err := r.ReadAt(buf, 0); err == nil {
+		t.Error("ReadAt with wrong AAD succeeded, want error")
+	}
+}

--- a/streamingaead/subtle/aes_ctr_hmac.go
+++ b/streamingaead/subtle/aes_ctr_hmac.go
@@ -224,7 +224,8 @@ func (a *AESCTRHMAC) NewEncryptingWriter(w io.Writer, aad []byte) (io.WriteClose
 
 type aesCTRHMACSegmentDecrypter struct {
 	blockCipher    cipher.Block
-	mac            hash.Hash
+	newHash        func() hash.Hash
+	hmacKey        []byte
 	tagSizeInBytes int
 }
 
@@ -249,10 +250,10 @@ func (d aesCTRHMACSegmentDecrypter) DecryptSegmentWithDst(dst, segment, nonce []
 	}
 	tag := segment[plaintextLen:]
 
-	d.mac.Reset()
-	d.mac.Write(nonce)
-	d.mac.Write(segment[:plaintextLen])
-	wantTag := d.mac.Sum(nil)[:d.tagSizeInBytes]
+	mac := hmac.New(d.newHash, d.hmacKey)
+	mac.Write(nonce)
+	mac.Write(segment[:plaintextLen])
+	wantTag := mac.Sum(nil)[:d.tagSizeInBytes]
 	if !hmac.Equal(tag, wantTag) {
 		return nil, errors.New("tag mismatch")
 	}
@@ -303,7 +304,8 @@ func (a *AESCTRHMAC) NewDecryptingReader(r io.Reader, aad []byte) (io.Reader, er
 		R: r,
 		SegmentDecrypter: aesCTRHMACSegmentDecrypter{
 			blockCipher:    blockCipher,
-			mac:            hmac.New(subtle.GetHashFunc(a.tagAlg), hmacKey),
+			newHash:        subtle.GetHashFunc(a.tagAlg),
+			hmacKey:        hmacKey,
 			tagSizeInBytes: a.tagSizeInBytes,
 		},
 		NonceSize:                    AESCTRHMACNonceSizeInBytes,
@@ -316,4 +318,55 @@ func (a *AESCTRHMAC) NewDecryptingReader(r io.Reader, aad []byte) (io.Reader, er
 	}
 
 	return &aesCTRHMACReader{Reader: nr}, nil
+}
+
+// NewDecryptingReaderAt returns an io.ReaderAt over the plaintext
+// corresponding to the ciphertext available via ct, using aad as associated
+// authenticated data.
+//
+// ct must provide the full ciphertext as written by NewEncryptingWriter (i.e.
+// offset 0 is the first byte of the stream header), and ctSize must be its
+// total length in bytes.
+//
+// The header is read and the per-stream keys derived eagerly. Segment
+// authentication is deferred until the corresponding plaintext bytes are read.
+func (a *AESCTRHMAC) NewDecryptingReaderAt(ct io.ReaderAt, ctSize int64, aad []byte) (*noncebased.ReaderAt, error) {
+	hlen := a.HeaderLength()
+	if ctSize < int64(hlen) {
+		return nil, errors.New("ciphertext too short")
+	}
+	header := make([]byte, hlen)
+	if _, err := io.ReadFull(io.NewSectionReader(ct, 0, int64(hlen)), header); err != nil {
+		return nil, fmt.Errorf("cannot read header: %v", err)
+	}
+	if header[0] != byte(hlen) {
+		return nil, errors.New("invalid header length")
+	}
+	salt := header[1 : 1+a.keySizeInBytes]
+	noncePrefix := header[1+a.keySizeInBytes:]
+
+	aesKey, hmacKey, err := a.deriveKeys(salt, aad)
+	if err != nil {
+		return nil, err
+	}
+	blockCipher, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return noncebased.NewReaderAt(noncebased.ReaderAtParams{
+		R:              io.NewSectionReader(ct, int64(hlen), ctSize-int64(hlen)),
+		CiphertextSize: ctSize - int64(hlen),
+		SegmentDecrypter: aesCTRHMACSegmentDecrypter{
+			blockCipher:    blockCipher,
+			newHash:        subtle.GetHashFunc(a.tagAlg),
+			hmacKey:        hmacKey,
+			tagSizeInBytes: a.tagSizeInBytes,
+		},
+		NonceSize:                    AESCTRHMACNonceSizeInBytes,
+		NoncePrefix:                  noncePrefix,
+		CiphertextSegmentSize:        a.ciphertextSegmentSize,
+		PlaintextSegmentSize:         a.plaintextSegmentSize,
+		FirstCiphertextSegmentOffset: a.firstCiphertextSegmentOffset,
+	})
 }

--- a/streamingaead/subtle/aes_gcm_hkdf.go
+++ b/streamingaead/subtle/aes_gcm_hkdf.go
@@ -261,3 +261,49 @@ func (a *AESGCMHKDF) NewDecryptingReader(r io.Reader, aad []byte) (io.Reader, er
 
 	return &aesGCMHKDFReader{Reader: nr}, nil
 }
+
+// NewDecryptingReaderAt returns an io.ReaderAt over the plaintext
+// corresponding to the ciphertext available via ct, using aad as associated
+// authenticated data.
+//
+// ct must provide the full ciphertext as written by NewEncryptingWriter (i.e.
+// offset 0 is the first byte of the stream header), and ctSize must be its
+// total length in bytes.
+//
+// The header is read and the per-stream key derived eagerly. Segment
+// authentication is deferred until the corresponding plaintext bytes are read.
+func (a *AESGCMHKDF) NewDecryptingReaderAt(ct io.ReaderAt, ctSize int64, aad []byte) (*noncebased.ReaderAt, error) {
+	hlen := a.HeaderLength()
+	if ctSize < int64(hlen) {
+		return nil, errors.New("ciphertext too short")
+	}
+	header := make([]byte, hlen)
+	if _, err := io.ReadFull(io.NewSectionReader(ct, 0, int64(hlen)), header); err != nil {
+		return nil, fmt.Errorf("cannot read header: %v", err)
+	}
+	if header[0] != byte(hlen) {
+		return nil, errors.New("invalid header length")
+	}
+	salt := header[1 : 1+a.keySizeInBytes]
+	noncePrefix := header[1+a.keySizeInBytes:]
+
+	dkey, err := a.deriveKey(salt, aad)
+	if err != nil {
+		return nil, err
+	}
+	cipher, err := a.newCipher(dkey)
+	if err != nil {
+		return nil, err
+	}
+
+	return noncebased.NewReaderAt(noncebased.ReaderAtParams{
+		R:                            io.NewSectionReader(ct, int64(hlen), ctSize-int64(hlen)),
+		CiphertextSize:               ctSize - int64(hlen),
+		SegmentDecrypter:             aesGCMHKDFSegmentDecrypter{cipher: cipher},
+		NonceSize:                    AESGCMHKDFNonceSizeInBytes,
+		NoncePrefix:                  noncePrefix,
+		CiphertextSegmentSize:        a.ciphertextSegmentSize,
+		PlaintextSegmentSize:         a.plaintextSegmentSize,
+		FirstCiphertextSegmentOffset: a.firstCiphertextSegmentOffset,
+	})
+}

--- a/streamingaead/subtle/noncebased/noncebased.go
+++ b/streamingaead/subtle/noncebased/noncebased.go
@@ -51,6 +51,7 @@ import (
 	"errors"
 	"io"
 	"math"
+	"sync/atomic"
 )
 
 var (
@@ -399,4 +400,297 @@ func generateSegmentNonce(size int, prefix []byte, segmentNum uint64, last bool)
 		nonce[offset] = 1
 	}
 	return nonce, nil
+}
+
+// ReaderAt provides random-access decryption of ciphertexts created using a
+// Writer.
+//
+// The scheme used for decrypting segments is specified by providing a
+// SegmentDecrypter implementation. The implementation must align with the
+// SegmentEncrypter used in the Writer.
+//
+// ReaderAt is safe for concurrent use; ReadAt calls execute in parallel. The
+// most recently decrypted segment is cached as an immutable snapshot via an
+// atomic pointer; concurrent reads of distinct segments may each decrypt and
+// the cache retains whichever store completes last.
+//
+// The provided SegmentDecrypter must be safe for concurrent DecryptSegment
+// calls.
+type ReaderAt struct {
+	r                            io.ReaderAt
+	segmentDecrypter             SegmentDecrypter
+	segmentDecrypterWithDst      segmentDecrypterWithDst
+	useSegmentDecrypterWithDst   bool
+	nonceSize                    int
+	noncePrefix                  []byte
+	ciphertextSegmentSize        int
+	plaintextSegmentSize         int
+	firstCiphertextSegmentOffset int
+	tagSize                      int
+
+	numberOfSegments          int64
+	lastCiphertextSegmentSize int
+	plaintextSize             int64
+
+	// cache holds the most recently decrypted segment. A stored cachedSegment
+	// is never mutated.
+	cache atomic.Pointer[cachedSegment]
+}
+
+type cachedSegment struct {
+	nr        int64
+	plaintext []byte
+}
+
+// ReaderAtParams contains the options for instantiating a ReaderAt via
+// NewReaderAt().
+type ReaderAtParams struct {
+	// R is the underlying ciphertext source. Offset 0 of R must correspond to
+	// the first byte of segment_0, i.e. the position of the stream immediately
+	// after the header has been consumed. This matches the semantics of
+	// ReaderParams.R.
+	R io.ReaderAt
+
+	// CiphertextSize is the total number of segment ciphertext bytes available
+	// via R (i.e. excluding the header).
+	CiphertextSize int64
+
+	// SegmentDecrypter provides a method for decrypting segments.
+	SegmentDecrypter SegmentDecrypter
+
+	// NonceSize is the length of generated nonces. It must match the NonceSize
+	// of the Writer used to create the ciphertext.
+	NonceSize int
+
+	// NoncePrefix is a constant that all nonces throughout the ciphertext start
+	// with. It's extracted from the header of the ciphertext.
+	NoncePrefix []byte
+
+	// CiphertextSegmentSize is the size of full ciphertext segments.
+	CiphertextSegmentSize int
+
+	// PlaintextSegmentSize is the size of full plaintext segments. It must equal
+	// CiphertextSegmentSize minus the per-segment authentication tag overhead.
+	PlaintextSegmentSize int
+
+	// FirstCiphertextSegmentOffset determines how many bytes segment_0's
+	// ciphertext is shortened by relative to CiphertextSegmentSize, accounting
+	// for the stream header and any caller alignment offset. R must still begin
+	// at the first byte of segment_0's ciphertext.
+	FirstCiphertextSegmentOffset int
+}
+
+// NewReaderAt creates a new ReaderAt instance.
+func NewReaderAt(params ReaderAtParams) (*ReaderAt, error) {
+	if params.NonceSize-len(params.NoncePrefix) < 5 {
+		return nil, ErrNonceSizeTooShort
+	}
+	tagSize := params.CiphertextSegmentSize - params.PlaintextSegmentSize
+	if tagSize <= 0 {
+		return nil, errors.New("ciphertext segment size must exceed plaintext segment size")
+	}
+	if params.FirstCiphertextSegmentOffset < 0 ||
+		params.FirstCiphertextSegmentOffset+tagSize >= params.CiphertextSegmentSize {
+		return nil, errors.New("invalid first ciphertext segment offset")
+	}
+	if params.CiphertextSize < int64(tagSize) {
+		return nil, errors.New("ciphertext too short")
+	}
+	if params.CiphertextSize > math.MaxInt64-int64(params.FirstCiphertextSegmentOffset) {
+		return nil, errors.New("ciphertext size too large")
+	}
+
+	streamSize := params.CiphertextSize + int64(params.FirstCiphertextSegmentOffset)
+	fullSegments := streamSize / int64(params.CiphertextSegmentSize)
+	remainder := streamSize % int64(params.CiphertextSegmentSize)
+	var (
+		numberOfSegments          int64
+		lastCiphertextSegmentSize int
+	)
+	if remainder > 0 {
+		numberOfSegments = fullSegments + 1
+		if remainder < int64(tagSize) {
+			return nil, errors.New("ciphertext too short")
+		}
+		lastCiphertextSegmentSize = int(remainder)
+	} else {
+		numberOfSegments = fullSegments
+		lastCiphertextSegmentSize = params.CiphertextSegmentSize
+	}
+	if numberOfSegments > math.MaxUint32 {
+		return nil, ErrTooManySegments
+	}
+
+	overhead := numberOfSegments * int64(tagSize)
+	if overhead > params.CiphertextSize {
+		return nil, errors.New("ciphertext too short")
+	}
+	plaintextSize := params.CiphertextSize - overhead
+
+	decrypterWithDst, useDecrypterWithDst := params.SegmentDecrypter.(segmentDecrypterWithDst)
+
+	r := &ReaderAt{
+		r:                            params.R,
+		segmentDecrypter:             params.SegmentDecrypter,
+		segmentDecrypterWithDst:      decrypterWithDst,
+		useSegmentDecrypterWithDst:   useDecrypterWithDst,
+		nonceSize:                    params.NonceSize,
+		noncePrefix:                  params.NoncePrefix,
+		ciphertextSegmentSize:        params.CiphertextSegmentSize,
+		plaintextSegmentSize:         params.PlaintextSegmentSize,
+		firstCiphertextSegmentOffset: params.FirstCiphertextSegmentOffset,
+		tagSize:                      tagSize,
+		numberOfSegments:             numberOfSegments,
+		lastCiphertextSegmentSize:    lastCiphertextSegmentSize,
+		plaintextSize:                plaintextSize,
+	}
+	if plaintextSize == 0 {
+		// An empty plaintext has no read that can reach the end of the
+		// stream, so decrypt the sole segment here instead. Without this a
+		// ciphertext truncated to just a header and a tag would present as a
+		// legitimately empty stream.
+		if _, err := r.loadSegment(numberOfSegments - 1); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
+}
+
+// Size returns the size of the plaintext.
+//
+// The returned value is derived from the ciphertext size provided at
+// construction time, which is not itself authenticated: a truncated stream
+// yields a smaller size. A read that reaches the end of the plaintext
+// decrypts the final segment and so fails on a truncated stream.
+func (r *ReaderAt) Size() int64 {
+	return r.plaintextSize
+}
+
+// segmentNr returns the segment number containing the given plaintext offset.
+func (r *ReaderAt) segmentNr(ptOff int64) int64 {
+	return (ptOff + int64(r.firstCiphertextSegmentOffset)) / int64(r.plaintextSegmentSize)
+}
+
+// ciphertextSegmentBounds returns the offset and length within r.r of the
+// ciphertext for the given segment number.
+func (r *ReaderAt) ciphertextSegmentBounds(segmentNr int64) (off int64, length int) {
+	length = r.ciphertextSegmentSize
+	if segmentNr == r.numberOfSegments-1 {
+		length = r.lastCiphertextSegmentSize
+	}
+	if segmentNr == 0 {
+		return 0, length - r.firstCiphertextSegmentOffset
+	}
+	return segmentNr*int64(r.ciphertextSegmentSize) - int64(r.firstCiphertextSegmentOffset), length
+}
+
+// CiphertextRange returns the byte range [off, off+n) within the underlying
+// ciphertext source that ReadAt will access in order to satisfy a plaintext
+// read of [ptOff, ptOff+ptLen). Callers backed by remote storage can use this
+// to prefetch the required bytes in a single round trip.
+//
+// The returned range covers whole ciphertext segments and does not include the
+// stream header.
+func (r *ReaderAt) CiphertextRange(ptOff, ptLen int64) (off, n int64) {
+	if ptLen <= 0 || ptOff < 0 || ptOff >= r.plaintextSize {
+		return 0, 0
+	}
+	end := ptOff + ptLen
+	if end > r.plaintextSize {
+		end = r.plaintextSize
+	}
+	firstOff, _ := r.ciphertextSegmentBounds(r.segmentNr(ptOff))
+	lastOff, lastLen := r.ciphertextSegmentBounds(r.segmentNr(end - 1))
+	return firstOff, lastOff + int64(lastLen) - firstOff
+}
+
+// loadSegment returns the decrypted plaintext of the given segment, using the
+// atomic cache if it already holds segmentNr. On a cache miss the segment is
+// fetched and decrypted into a fresh buffer which is then stored in the cache
+// and returned; the returned slice is never subsequently mutated.
+func (r *ReaderAt) loadSegment(segmentNr int64) ([]byte, error) {
+	if cs := r.cache.Load(); cs != nil && cs.nr == segmentNr {
+		return cs.plaintext, nil
+	}
+	ctOff, ctLen := r.ciphertextSegmentBounds(segmentNr)
+	ct := make([]byte, ctLen)
+	if _, err := readFullAt(r.r, ct, ctOff); err != nil {
+		return nil, err
+	}
+	isLast := segmentNr == r.numberOfSegments-1
+	nonce, err := generateSegmentNonce(r.nonceSize, r.noncePrefix, uint64(segmentNr), isLast)
+	if err != nil {
+		return nil, err
+	}
+	var pt []byte
+	if r.useSegmentDecrypterWithDst {
+		pt, err = r.segmentDecrypterWithDst.DecryptSegmentWithDst(nil, ct, nonce)
+	} else {
+		pt, err = r.segmentDecrypter.DecryptSegment(ct, nonce)
+	}
+	if err != nil {
+		return nil, err
+	}
+	r.cache.Store(&cachedSegment{nr: segmentNr, plaintext: pt})
+	return pt, nil
+}
+
+// ReadAt decrypts and returns plaintext bytes at the given offset. It
+// implements io.ReaderAt.
+func (r *ReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if off < 0 {
+		return 0, errors.New("negative offset")
+	}
+	n := 0
+	for n < len(p) && off < r.plaintextSize {
+		segNr := r.segmentNr(off)
+		var segOff int
+		if segNr == 0 {
+			segOff = int(off)
+		} else {
+			segOff = int((off + int64(r.firstCiphertextSegmentOffset)) % int64(r.plaintextSegmentSize))
+		}
+		pt, err := r.loadSegment(segNr)
+		if err != nil {
+			return n, err
+		}
+		c := copy(p[n:], pt[segOff:])
+		n += c
+		off += int64(c)
+	}
+	if len(p) > 0 && off >= r.plaintextSize {
+		// Only the last segment's nonce carries the flag marking the end of
+		// the stream, so a read that reaches the end of the plaintext must
+		// decrypt that segment to establish that the ciphertext is complete.
+		// The loop above already did so unless the last segment holds no
+		// plaintext, which is the case whenever the plaintext length is a
+		// multiple of the segment size.
+		if _, err := r.loadSegment(r.numberOfSegments - 1); err != nil {
+			return n, err
+		}
+	}
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// readFullAt reads exactly len(buf) bytes from r at the given offset.
+//
+// The io.ReaderAt contract requires a non-nil error whenever n < len(buf), so a
+// single call would normally suffice; this loops defensively to tolerate
+// non-conforming implementations.
+func readFullAt(r io.ReaderAt, buf []byte, off int64) (int, error) {
+	n := 0
+	for n < len(buf) {
+		m, err := r.ReadAt(buf[n:], off+int64(n))
+		n += m
+		if err != nil {
+			if err == io.EOF && n == len(buf) {
+				return n, nil
+			}
+			return n, err
+		}
+	}
+	return n, nil
 }

--- a/streamingaead/subtle/noncebased/noncebased_readerat_test.go
+++ b/streamingaead/subtle/noncebased/noncebased_readerat_test.go
@@ -1,0 +1,339 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noncebased_test
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/tink-crypto/tink-go/v2/streamingaead/subtle/noncebased"
+)
+
+// readerAtTestParams describes a (plaintext size, segment geometry) combination
+// used by the ReaderAt tests.
+type readerAtTestParams struct {
+	name                         string
+	plaintextSize                int
+	nonceSize                    int
+	noncePrefixSize              int
+	plaintextSegmentSize         int
+	firstCiphertextSegmentOffset int
+}
+
+func readerAtTestCases() []readerAtTestParams {
+	return []readerAtTestParams{
+		{"aligned", 100, 10, 5, 20, 10},
+		{"unaligned", 110, 10, 5, 20, 10},
+		{"twoSegments", 25, 10, 5, 20, 10},
+		{"shortPlaintext", 1, 10, 5, 100, 10},
+		{"empty", 0, 10, 5, 100, 10},
+		{"manySegments", 1000, 10, 5, 17, 10},
+		{"exactlyFirstSegment", 10, 10, 5, 20, 10},
+	}
+}
+
+// newReaderAtFixture encrypts a deterministic plaintext via the noncebased
+// Writer and returns the plaintext, the full ciphertext (with a synthetic
+// header of firstCiphertextSegmentOffset bytes), and a constructed ReaderAt.
+func newReaderAtFixture(t testing.TB, tc readerAtTestParams) ([]byte, []byte, *noncebased.ReaderAt) {
+	t.Helper()
+	pt, segments, noncePrefix, err := testEncrypt(tc.plaintextSize, tc.noncePrefixSize, noncebased.WriterParams{
+		NonceSize:                    tc.nonceSize,
+		PlaintextSegmentSize:         tc.plaintextSegmentSize,
+		FirstCiphertextSegmentOffset: tc.firstCiphertextSegmentOffset,
+	})
+	if err != nil {
+		t.Fatalf("testEncrypt: %v", err)
+	}
+	r, err := noncebased.NewReaderAt(noncebased.ReaderAtParams{
+		R:                            bytes.NewReader(segments),
+		CiphertextSize:               int64(len(segments)),
+		SegmentDecrypter:             testDecrypterWithDst{},
+		NonceSize:                    tc.nonceSize,
+		NoncePrefix:                  noncePrefix,
+		CiphertextSegmentSize:        tc.plaintextSegmentSize + tc.nonceSize,
+		PlaintextSegmentSize:         tc.plaintextSegmentSize,
+		FirstCiphertextSegmentOffset: tc.firstCiphertextSegmentOffset,
+	})
+	if err != nil {
+		t.Fatalf("NewReaderAt: %v", err)
+	}
+	return pt, segments, r
+}
+
+func TestReaderAtSize(t *testing.T) {
+	for _, tc := range readerAtTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			pt, _, r := newReaderAtFixture(t, tc)
+			if got, want := r.Size(), int64(len(pt)); got != want {
+				t.Errorf("Size() = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestReaderAtFullRead(t *testing.T) {
+	for _, tc := range readerAtTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			pt, _, r := newReaderAtFixture(t, tc)
+			got := make([]byte, len(pt))
+			n, err := r.ReadAt(got, 0)
+			if err != nil && err != io.EOF {
+				t.Fatalf("ReadAt(0) err = %v", err)
+			}
+			if n != len(pt) {
+				t.Fatalf("ReadAt(0) n = %d, want %d", n, len(pt))
+			}
+			if !bytes.Equal(got, pt) {
+				t.Errorf("plaintext mismatch")
+			}
+		})
+	}
+}
+
+func TestReaderAtPastEnd(t *testing.T) {
+	for _, tc := range readerAtTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			pt, _, r := newReaderAtFixture(t, tc)
+			buf := make([]byte, 4)
+			n, err := r.ReadAt(buf, int64(len(pt)))
+			if n != 0 || err != io.EOF {
+				t.Errorf("ReadAt(len(pt)) = (%d, %v), want (0, io.EOF)", n, err)
+			}
+		})
+	}
+}
+
+func BenchmarkReaderAtParallel(b *testing.B) {
+	tc := readerAtTestParams{"bench", 64 * 1024, 12, 7, 4096, 12}
+	pt, _, r := newReaderAtFixture(b, tc)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		rng := rand.New(rand.NewSource(rand.Int63()))
+		buf := make([]byte, 256)
+		for pb.Next() {
+			off := rng.Int63n(int64(len(pt) - len(buf)))
+			if _, err := r.ReadAt(buf, off); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func TestReaderAtOffsets(t *testing.T) {
+	for _, tc := range readerAtTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			pt, _, r := newReaderAtFixture(t, tc)
+			seg0Pt := tc.plaintextSegmentSize - tc.firstCiphertextSegmentOffset
+			reads := []struct {
+				name string
+				off  int64
+				len  int
+			}{
+				{"start", 0, 5},
+				{"midSegment", 3, 4},
+				{"segmentBoundary", int64(seg0Pt), 5},
+				{"acrossTwoSegments", int64(seg0Pt) - 2, 6},
+				{"acrossManySegments", 0, 3*tc.plaintextSegmentSize + 1},
+				{"tail", int64(len(pt)) - 3, 3},
+				{"atEOF", int64(len(pt)), 1},
+				{"pastEOF", int64(len(pt)) + 5, 1},
+			}
+			for _, rd := range reads {
+				t.Run(rd.name, func(t *testing.T) {
+					if rd.off < 0 {
+						return
+					}
+					buf := make([]byte, rd.len)
+					n, err := r.ReadAt(buf, rd.off)
+					var want []byte
+					if rd.off < int64(len(pt)) {
+						end := rd.off + int64(rd.len)
+						if end > int64(len(pt)) {
+							end = int64(len(pt))
+						}
+						want = pt[rd.off:end]
+					}
+					if n != len(want) {
+						t.Fatalf("n = %d, want %d (err = %v)", n, len(want), err)
+					}
+					if !bytes.Equal(buf[:n], want) {
+						t.Errorf("data mismatch at off=%d", rd.off)
+					}
+					if n < rd.len && err != io.EOF {
+						t.Errorf("short read at off=%d returned err = %v, want io.EOF", rd.off, err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestReaderAtRandomAccess(t *testing.T) {
+	tc := readerAtTestParams{"random", 5000, 10, 5, 23, 10}
+	pt, _, r := newReaderAtFixture(t, tc)
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 200; i++ {
+		off := rng.Int63n(int64(len(pt)))
+		l := rng.Intn(100) + 1
+		buf := make([]byte, l)
+		n, err := r.ReadAt(buf, off)
+		end := int(off) + l
+		if end > len(pt) {
+			end = len(pt)
+		}
+		want := pt[off:end]
+		if n != len(want) {
+			t.Fatalf("iter %d: n = %d, want %d (err = %v)", i, n, len(want), err)
+		}
+		if !bytes.Equal(buf[:n], want) {
+			t.Fatalf("iter %d: mismatch at off=%d", i, off)
+		}
+		if n < l && err != io.EOF {
+			t.Fatalf("iter %d: short read err = %v, want io.EOF", i, err)
+		}
+	}
+}
+
+func TestReaderAtConcurrent(t *testing.T) {
+	tc := readerAtTestParams{"concurrent", 4000, 10, 5, 31, 10}
+	pt, _, r := newReaderAtFixture(t, tc)
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(seed int64) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(seed))
+			for i := 0; i < 50; i++ {
+				off := rng.Int63n(int64(len(pt)))
+				l := rng.Intn(64) + 1
+				buf := make([]byte, l)
+				n, err := r.ReadAt(buf, off)
+				end := int(off) + l
+				if end > len(pt) {
+					end = len(pt)
+				}
+				if n != end-int(off) || !bytes.Equal(buf[:n], pt[off:end]) {
+					t.Errorf("mismatch at off=%d (err=%v)", off, err)
+					return
+				}
+			}
+		}(int64(g))
+	}
+	wg.Wait()
+}
+
+func TestReaderAtCiphertextRange(t *testing.T) {
+	tc := readerAtTestParams{"range", 200, 10, 5, 20, 10}
+	_, ct, r := newReaderAtFixture(t, tc)
+	ctSegSize := int64(tc.plaintextSegmentSize + tc.nonceSize)
+	seg0Ct := ctSegSize - int64(tc.firstCiphertextSegmentOffset)
+	seg0Pt := int64(tc.plaintextSegmentSize - tc.firstCiphertextSegmentOffset)
+
+	cases := []struct {
+		name              string
+		ptOff, ptLen      int64
+		wantOff, wantHigh int64
+	}{
+		{"firstByte", 0, 1, 0, seg0Ct},
+		{"spanTwo", seg0Pt - 1, 2, 0, seg0Ct + ctSegSize},
+		{"secondSeg", seg0Pt, 1, seg0Ct, seg0Ct + ctSegSize},
+		{"full", 0, r.Size(), 0, int64(len(ct))},
+		{"zeroLen", 5, 0, 0, 0},
+		{"pastEOF", r.Size() + 1, 5, 0, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotOff, gotN := r.CiphertextRange(c.ptOff, c.ptLen)
+			if gotOff != c.wantOff || gotOff+gotN != c.wantHigh {
+				t.Errorf("CiphertextRange(%d,%d) = [%d,%d), want [%d,%d)",
+					c.ptOff, c.ptLen, gotOff, gotOff+gotN, c.wantOff, c.wantHigh)
+			}
+		})
+	}
+}
+
+func TestReaderAtTamperedCiphertext(t *testing.T) {
+	tc := readerAtTestParams{"tamper", 100, 10, 5, 20, 10}
+	_, ct, _ := newReaderAtFixture(t, tc)
+	// Flip a byte inside segment_1.
+	seg0Ct := tc.plaintextSegmentSize + tc.nonceSize - tc.firstCiphertextSegmentOffset
+	ct[seg0Ct+2] ^= 0x01
+	r, err := noncebased.NewReaderAt(noncebased.ReaderAtParams{
+		R:                            bytes.NewReader(ct),
+		CiphertextSize:               int64(len(ct)),
+		SegmentDecrypter:             testDecrypterWithDst{},
+		NonceSize:                    tc.nonceSize,
+		NoncePrefix:                  make([]byte, tc.noncePrefixSize),
+		CiphertextSegmentSize:        tc.plaintextSegmentSize + tc.nonceSize,
+		PlaintextSegmentSize:         tc.plaintextSegmentSize,
+		FirstCiphertextSegmentOffset: tc.firstCiphertextSegmentOffset,
+	})
+	if err != nil {
+		t.Fatalf("NewReaderAt: %v", err)
+	}
+	buf := make([]byte, 5)
+	if _, err := r.ReadAt(buf, int64(tc.plaintextSegmentSize-tc.firstCiphertextSegmentOffset)); err == nil {
+		t.Error("ReadAt of tampered segment succeeded, want error")
+	}
+}
+
+func TestReaderAtNegativeOffset(t *testing.T) {
+	tc := readerAtTestParams{"neg", 100, 10, 5, 20, 10}
+	_, _, r := newReaderAtFixture(t, tc)
+	if _, err := r.ReadAt(make([]byte, 4), -1); err == nil {
+		t.Error("ReadAt(-1) succeeded, want error")
+	}
+}
+
+func TestNewReaderAtInvalidParams(t *testing.T) {
+	base := noncebased.ReaderAtParams{
+		R:                            bytes.NewReader(make([]byte, 100)),
+		CiphertextSize:               100,
+		SegmentDecrypter:             testDecrypterWithDst{},
+		NonceSize:                    10,
+		NoncePrefix:                  make([]byte, 5),
+		CiphertextSegmentSize:        30,
+		PlaintextSegmentSize:         20,
+		FirstCiphertextSegmentOffset: 10,
+	}
+	cases := []struct {
+		name   string
+		mutate func(*noncebased.ReaderAtParams)
+	}{
+		{"nonceTooShort", func(p *noncebased.ReaderAtParams) { p.NonceSize = 5 }},
+		{"segmentSizes", func(p *noncebased.ReaderAtParams) { p.PlaintextSegmentSize = 30 }},
+		{"ciphertextTooShort", func(p *noncebased.ReaderAtParams) { p.CiphertextSize = 5 }},
+		{"offsetTooLarge", func(p *noncebased.ReaderAtParams) { p.FirstCiphertextSegmentOffset = 25 }},
+		{"remainderTooShort", func(p *noncebased.ReaderAtParams) { p.CiphertextSize = 21 }},
+		{"sizeOverflow", func(p *noncebased.ReaderAtParams) { p.CiphertextSize = math.MaxInt64 }},
+		{"tooManySegments", func(p *noncebased.ReaderAtParams) {
+			p.CiphertextSize = int64(p.CiphertextSegmentSize) * (int64(math.MaxUint32) + 2)
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := base
+			c.mutate(&p)
+			if _, err := noncebased.NewReaderAt(p); err == nil {
+				t.Error("NewReaderAt succeeded, want error")
+			}
+		})
+	}
+}

--- a/streamingaead/subtle/subtle_readerat_test.go
+++ b/streamingaead/subtle/subtle_readerat_test.go
@@ -1,0 +1,332 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subtle_test
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/tink-crypto/tink-go/v2/streamingaead/subtle"
+	"github.com/tink-crypto/tink-go/v2/streamingaead/subtle/noncebased"
+)
+
+type readerAtCipher interface {
+	NewEncryptingWriter(io.Writer, []byte) (io.WriteCloser, error)
+	NewDecryptingReaderAt(io.ReaderAt, int64, []byte) (*noncebased.ReaderAt, error)
+	HeaderLength() int
+}
+
+func newReaderAtCiphers(t *testing.T) map[string]readerAtCipher {
+	t.Helper()
+	gcm, err := subtle.NewAESGCMHKDF(ikm, "SHA256", 16, 256, 0)
+	if err != nil {
+		t.Fatalf("NewAESGCMHKDF: %v", err)
+	}
+	gcmOffset, err := subtle.NewAESGCMHKDF(ikm, "SHA256", 16, 256, 8)
+	if err != nil {
+		t.Fatalf("NewAESGCMHKDF: %v", err)
+	}
+	ctr, err := subtle.NewAESCTRHMAC(ikm, "SHA256", 16, "SHA256", 16, 256, 0)
+	if err != nil {
+		t.Fatalf("NewAESCTRHMAC: %v", err)
+	}
+	return map[string]readerAtCipher{
+		"AESGCMHKDF":          gcm,
+		"AESGCMHKDF-offset-8": gcmOffset,
+		"AESCTRHMAC":          ctr,
+	}
+}
+
+func TestNewDecryptingReaderAt(t *testing.T) {
+	for name, cipher := range newReaderAtCiphers(t) {
+		t.Run(name, func(t *testing.T) {
+			for _, ptSize := range []int{0, 1, 200, 1000, 5000} {
+				pt, ct, err := encryptReaderAt(cipher, ptSize)
+				if err != nil {
+					t.Fatalf("encrypt(%d): %v", ptSize, err)
+				}
+				r, err := cipher.NewDecryptingReaderAt(bytes.NewReader(ct), int64(len(ct)), aad)
+				if err != nil {
+					t.Fatalf("NewDecryptingReaderAt(%d): %v", ptSize, err)
+				}
+				if got, want := r.Size(), int64(ptSize); got != want {
+					t.Errorf("Size() = %d, want %d", got, want)
+				}
+				got := make([]byte, ptSize)
+				if n, err := r.ReadAt(got, 0); n != ptSize || (err != nil && err != io.EOF) {
+					t.Fatalf("ReadAt(0) = %d, %v; want %d, nil", n, err, ptSize)
+				}
+				if !bytes.Equal(got, pt) {
+					t.Errorf("plaintext mismatch (size %d)", ptSize)
+				}
+			}
+		})
+	}
+}
+
+func TestNewDecryptingReaderAtRandomOffsets(t *testing.T) {
+	for name, cipher := range newReaderAtCiphers(t) {
+		t.Run(name, func(t *testing.T) {
+			pt, ct, err := encryptReaderAt(cipher, 8000)
+			if err != nil {
+				t.Fatalf("encrypt: %v", err)
+			}
+			r, err := cipher.NewDecryptingReaderAt(bytes.NewReader(ct), int64(len(ct)), aad)
+			if err != nil {
+				t.Fatalf("NewDecryptingReaderAt: %v", err)
+			}
+			rng := rand.New(rand.NewSource(42))
+			for i := 0; i < 200; i++ {
+				off := rng.Int63n(int64(len(pt)))
+				l := rng.Intn(400) + 1
+				buf := make([]byte, l)
+				n, err := r.ReadAt(buf, off)
+				end := int(off) + l
+				if end > len(pt) {
+					end = len(pt)
+				}
+				if n != end-int(off) || !bytes.Equal(buf[:n], pt[off:end]) {
+					t.Fatalf("iter %d: mismatch at off=%d (n=%d, err=%v)", i, off, n, err)
+				}
+			}
+		})
+	}
+}
+
+func TestNewDecryptingReaderAtBadAAD(t *testing.T) {
+	for name, cipher := range newReaderAtCiphers(t) {
+		t.Run(name, func(t *testing.T) {
+			_, ct, err := encryptReaderAt(cipher, 500)
+			if err != nil {
+				t.Fatalf("encrypt: %v", err)
+			}
+			r, err := cipher.NewDecryptingReaderAt(bytes.NewReader(ct), int64(len(ct)), []byte("wrong"))
+			if err != nil {
+				t.Fatalf("NewDecryptingReaderAt: %v", err)
+			}
+			buf := make([]byte, 10)
+			if _, err := r.ReadAt(buf, 0); err == nil {
+				t.Error("ReadAt with wrong AAD succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestNewDecryptingReaderAtTruncated(t *testing.T) {
+	for name, cipher := range newReaderAtCiphers(t) {
+		t.Run(name, func(t *testing.T) {
+			_, ct, err := encryptReaderAt(cipher, 500)
+			if err != nil {
+				t.Fatalf("encrypt: %v", err)
+			}
+			if _, err := cipher.NewDecryptingReaderAt(bytes.NewReader(ct), 5, aad); err == nil {
+				t.Error("NewDecryptingReaderAt with size < header succeeded, want error")
+			}
+			bad := make([]byte, len(ct))
+			copy(bad, ct)
+			bad[0] = 0
+			if _, err := cipher.NewDecryptingReaderAt(bytes.NewReader(bad), int64(len(bad)), aad); err == nil {
+				t.Error("NewDecryptingReaderAt with bad header byte succeeded, want error")
+			}
+		})
+	}
+}
+
+// readerAtModifyCipher pairs a readerAtCipher with the segment geometry needed
+// to compute segment boundaries for tamper tests.
+type readerAtModifyCipher struct {
+	name               string
+	cipher             readerAtCipher
+	segmentSize        int
+	firstSegmentOffset int
+}
+
+func newReaderAtModifyCiphers(t *testing.T) []readerAtModifyCipher {
+	t.Helper()
+	gcm, err := subtle.NewAESGCMHKDF(ikm, "SHA256", 16, 256, 8)
+	if err != nil {
+		t.Fatalf("NewAESGCMHKDF: %v", err)
+	}
+	ctr, err := subtle.NewAESCTRHMAC(ikm, "SHA256", 16, "SHA256", 16, 256, 8)
+	if err != nil {
+		t.Fatalf("NewAESCTRHMAC: %v", err)
+	}
+	return []readerAtModifyCipher{
+		{"AESGCMHKDF", gcm, 256, 8},
+		{"AESCTRHMAC", ctr, 256, 8},
+	}
+}
+
+// checkReaderAtDetectsTampering constructs a ReaderAt over a tampered
+// ciphertext and asserts that reads at an exponential grid of (offset, length)
+// positions either fail or return bytes identical to the original plaintext.
+// It returns the number of grid positions at which an error was reported.
+func checkReaderAtDetectsTampering(t *testing.T, c readerAtCipher, pt, tamperedCt []byte) int {
+	t.Helper()
+	r, err := c.NewDecryptingReaderAt(bytes.NewReader(tamperedCt), int64(len(tamperedCt)), aad)
+	if err != nil {
+		return 1
+	}
+	failures := 0
+	for start := 0; start < len(pt); start = 2*start + 1 {
+		for l := 1; l < len(pt); l *= 2 {
+			buf := make([]byte, l)
+			n, err := r.ReadAt(buf, int64(start))
+			if err != nil && err != io.EOF {
+				failures++
+				continue
+			}
+			end := start + n
+			if end > len(pt) {
+				t.Fatalf("ReadAt(%d,%d) returned n=%d past plaintext", start, l, n)
+			}
+			if !bytes.Equal(buf[:n], pt[start:end]) {
+				t.Fatalf("ReadAt(%d,%d) returned corrupted plaintext", start, l)
+			}
+		}
+	}
+	return failures
+}
+
+// readWholePlaintext constructs a ReaderAt over ct and reads every byte of
+// the plaintext it reports, plus one past the end so that the final segment
+// is decrypted. It returns nil only if the ciphertext was accepted in full.
+func readWholePlaintext(c readerAtCipher, ct []byte) error {
+	r, err := c.NewDecryptingReaderAt(bytes.NewReader(ct), int64(len(ct)), aad)
+	if err != nil {
+		return err
+	}
+	buf := make([]byte, r.Size()+1)
+	if _, err := r.ReadAt(buf, 0); err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+}
+
+func TestReaderAtModifiedCiphertext(t *testing.T) {
+	const plaintextSize = 1024
+	for _, mc := range newReaderAtModifyCiphers(t) {
+		t.Run(mc.name, func(t *testing.T) {
+			pt, ct, err := encryptReaderAt(mc.cipher, plaintextSize)
+			if err != nil {
+				t.Fatalf("encrypt: %v", err)
+			}
+			headerLen := mc.cipher.HeaderLength()
+
+			t.Run("truncate", func(t *testing.T) {
+				// A ReaderAt over a prefix of the ciphertext may legitimately
+				// return correct plaintext for segments lying entirely within
+				// that prefix, so an individual read need not fail. Reading
+				// the whole plaintext must, because it decrypts the final
+				// segment, whose nonce marks the end of the stream.
+				for i := 0; i < len(ct); i += 8 {
+					checkReaderAtDetectsTampering(t, mc.cipher, pt, ct[:i])
+					if err := readWholePlaintext(mc.cipher, ct[:i]); err == nil {
+						t.Errorf("truncated to %d/%d bytes: reading the whole plaintext returned nil error, want error", i, len(ct))
+					}
+				}
+			})
+			t.Run("append", func(t *testing.T) {
+				for _, size := range []int{1, mc.segmentSize - len(ct)%mc.segmentSize, mc.segmentSize} {
+					ct2 := make([]byte, len(ct)+size)
+					copy(ct2, ct)
+					if checkReaderAtDetectsTampering(t, mc.cipher, pt, ct2) == 0 {
+						t.Errorf("append %d bytes: no read failed", size)
+					}
+				}
+			})
+			t.Run("flip bits", func(t *testing.T) {
+				for i := range ct {
+					ct2 := make([]byte, len(ct))
+					copy(ct2, ct)
+					ct2[i] ^= 1
+					if checkReaderAtDetectsTampering(t, mc.cipher, pt, ct2) == 0 {
+						t.Errorf("flip byte %d: no read failed", i)
+					}
+				}
+			})
+			t.Run("delete segments", func(t *testing.T) {
+				for i := 0; i < len(ct)/mc.segmentSize+1; i++ {
+					start, end := segmentPos(mc.segmentSize, mc.firstSegmentOffset, headerLen, i)
+					if start > len(ct) {
+						break
+					}
+					if end > len(ct) {
+						end = len(ct)
+					}
+					ct2 := make([]byte, 0, len(ct))
+					ct2 = append(ct2, ct[:start]...)
+					ct2 = append(ct2, ct[end:]...)
+					if checkReaderAtDetectsTampering(t, mc.cipher, pt, ct2) == 0 {
+						t.Errorf("delete segment %d: no read failed", i)
+					}
+				}
+			})
+			t.Run("duplicate segments", func(t *testing.T) {
+				for i := 0; i < len(ct)/mc.segmentSize+1; i++ {
+					start, end := segmentPos(mc.segmentSize, mc.firstSegmentOffset, headerLen, i)
+					if start > len(ct) {
+						break
+					}
+					if end > len(ct) {
+						end = len(ct)
+					}
+					ct2 := make([]byte, 0, len(ct)+end-start)
+					ct2 = append(ct2, ct[:end]...)
+					ct2 = append(ct2, ct[start:]...)
+					if checkReaderAtDetectsTampering(t, mc.cipher, pt, ct2) == 0 {
+						t.Errorf("duplicate segment %d: no read failed", i)
+					}
+				}
+			})
+			t.Run("modify aad", func(t *testing.T) {
+				for i := range aad {
+					aad2 := make([]byte, len(aad))
+					copy(aad2, aad)
+					aad2[i] ^= 1
+					r, err := mc.cipher.NewDecryptingReaderAt(bytes.NewReader(ct), int64(len(ct)), aad2)
+					if err != nil {
+						continue
+					}
+					buf := make([]byte, 16)
+					if _, err := r.ReadAt(buf, 0); err == nil {
+						t.Errorf("modified aad byte %d: ReadAt succeeded, want error", i)
+					}
+				}
+			})
+		})
+	}
+}
+
+func encryptReaderAt(cipher readerAtCipher, ptSize int) ([]byte, []byte, error) {
+	pt := make([]byte, ptSize)
+	for i := range pt {
+		pt[i] = byte(i % 251)
+	}
+	var buf bytes.Buffer
+	w, err := cipher.NewEncryptingWriter(&buf, aad)
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, err := w.Write(pt); err != nil {
+		return nil, nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, nil, err
+	}
+	return pt, buf.Bytes(), nil
+}


### PR DESCRIPTION
## Summary

Adds `streamingaead.NewDecryptingReaderAt`, the Go counterpart to Java's `StreamingAead.newSeekableDecryptingChannel`. This enables random-access decryption of streaming AEAD ciphertexts — for example, reading an arbitrary byte range from a large encrypted blob in object storage without downloading and decrypting the whole stream.

## API

```go
package streamingaead

// SizedReaderAt is an io.ReaderAt that reports its size. *bytes.Reader and
// *io.SectionReader implement it.
type SizedReaderAt interface {
    io.ReaderAt
    Size() int64
}

func NewDecryptingReaderAt(h *keyset.Handle, ct SizedReaderAt, aad []byte) (*DecryptingReaderAt, error)

func (r *DecryptingReaderAt) ReadAt(p []byte, off int64) (int, error)
func (r *DecryptingReaderAt) Size() int64
func (r *DecryptingReaderAt) CiphertextRange(ptOff, ptLen int64) (off, n int64)
```

`CiphertextRange` returns the underlying ciphertext byte range that `ReadAt` will request for a given plaintext range, so callers backed by remote storage can fetch one contiguous range up front instead of one round-trip per segment.

## Implementation notes

- The segment index for a plaintext offset and the per-segment ciphertext bounds are computed using the same arithmetic as `StreamingAeadSeekableDecryptingChannel` in tink-java.
- `ReadAt` is safe for concurrent use and executes in parallel: all per-stream state (derived key, nonce prefix, segment geometry) is immutable after construction, the most-recently-decrypted segment is cached behind an `atomic.Pointer`, and segment decryption allocates fresh working buffers per call.
- To make the AES-CTR-HMAC segment decrypter safe for concurrent use, it now stores the HMAC key and hash constructor and creates a fresh `hmac.New` per segment instead of reusing a single `hash.Hash`. This also affects the existing `NewDecryptingReader` path; the per-segment cost is negligible relative to MAC computation over the segment.
- For multi-key keysets the matching key is selected lazily on the first `ReadAt`, so reading at a large offset does not force a fetch of segment 0.

## Testing

- Correctness: full reads, boundary/spanning offsets, exponential `(offset, len)` grid, random-access fuzz, both AES-GCM-HKDF and AES-CTR-HMAC, multiple key templates and segment sizes, multi-key keysets.
- Adversarial (`TestReaderAtModifiedCiphertext`, mirroring the existing `TestAESCTRHMACModifiedCiphertext`): truncation at every 8 bytes (each asserted to fail a full-plaintext read), appended garbage, every-byte bit flip, segment deletion, segment duplication, AAD modification — each verified at many offsets to assert no read ever returns corrupted plaintext.
- `SizedReaderAt` reporting an incorrect size (`TestDecryptingReaderAtWrongSize`).
- Concurrency: parallel `ReadAt` from multiple goroutines under `-race`, plus a `RunParallel` benchmark.

## Truncation

Random access authenticates what it reads, so a read of a leading segment succeeds whether or not later segments are present, and `Size()` is derived from the ciphertext length rather than from anything authenticated. What must not happen is for a caller who reads the whole plaintext to accept a truncated stream, and that is what the last-segment nonce flag establishes.

A read that reaches the end of the plaintext therefore decrypts the final segment even when that segment carries no plaintext bytes, which is the case whenever the plaintext length is a multiple of the segment size. Without this, a stream cut to whole segments plus a tag would report a smaller `Size()` and return that many correct bytes with no error, while the sequential `Reader` rejects the same input. Reading the whole plaintext, or a single byte at `Size()-1`, is thus sufficient to establish that the size is genuine. An empty plaintext has no read that can reach its final segment, so that one is decrypted when the reader is constructed.

`TestReaderAtModifiedCiphertext/truncate` asserts this over every truncation length: for each, reading the whole plaintext must fail.

## Commits

This PR is structured as three reviewable commits (noncebased core → subtle primitive wiring → keyset wrapper); each builds and passes tests independently.

