### PR TITLE
implement safe type assertions in PRF constructors to prevent runtime…

### DIFF
--- a/prf/hkdfprf/key.go
+++ b/prf/hkdfprf/key.go
@@ -63,10 +63,18 @@ func primitiveConstructor(key key.Key) (any, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid key type: got %T, want %T", key, (*Key)(nil))
 	}
-	params := actualKey.Parameters().(*Parameters)
+    
+    // here we apply secuity patch
+	params, ok := actualKey.Parameters().(*Parameters)
+	if !ok {
+		return nil, fmt.Errorf("hkdfprf: internal error, invalid parameters type")
+	}
+
+    // we mantain original validation
 	if err := subtle.ValidateHKDFPRFParams(params.HashType().String(), uint32(params.KeySizeInBytes()), params.Salt()); err != nil {
 		return nil, err
 	}
+    
 	return subtle.NewHKDFPRF(params.HashType().String(), actualKey.KeyBytes().Data(insecuresecretdataaccess.Token{}), params.Salt())
 }
 

--- a/prf/hkdfprf/key.go
+++ b/prf/hkdfprf/key.go
@@ -64,13 +64,12 @@ func primitiveConstructor(key key.Key) (any, error) {
 		return nil, fmt.Errorf("invalid key type: got %T, want %T", key, (*Key)(nil))
 	}
     
-    // here we apply secuity patch
+    
 	params, ok := actualKey.Parameters().(*Parameters)
-	if !ok {
-		return nil, fmt.Errorf("hkdfprf: internal error, invalid parameters type")
-	}
-
-    // we mantain original validation
+	
+if !ok {
+    return nil, fmt.Errorf("invalid parameters type: %T", actualKey.Parameters())
+}    
 	if err := subtle.ValidateHKDFPRFParams(params.HashType().String(), uint32(params.KeySizeInBytes()), params.Salt()); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
… panics

## Summary:

This PR replaces unsafe direct type assertions with the "comma-ok" idiom in the `primitiveConstructor` for `hkdfprf`

## Changes
- Replaced `actualKey.Parameters().(*Parameters)` with a safe type  check.

- Added structured error handling to return an `error` instead of triggering a runtime panic (DoS).


- **Ensured that `subtle.ValidateHKDFPRFParams` remains intact to maintain cryptographic parameter validation.**


# Fixes #503107367