### PR TITLE
Use FIPS-compatible stdlib components for AEAD where possible

### DIFF
--- a/aead/aesctrhmac/aead_test.go
+++ b/aead/aesctrhmac/aead_test.go
@@ -249,7 +249,7 @@ func TestAEADEncryptDecrypt(t *testing.T) {
 	const tagSize = 16
 	for _, variant := range []aesctrhmac.Variant{aesctrhmac.VariantNoPrefix, aesctrhmac.VariantTink, aesctrhmac.VariantCrunchy} {
 		t.Run(variant.String(), func(t *testing.T) {
-			cipher, err := createAEAD([]byte("1111111111111111"), ivSize, aesctrhmac.SHA1, []byte("2222222222222222"), tagSize, variant, 0)
+			cipher, err := createAEAD([]byte("1111111111111111"), ivSize, aesctrhmac.SHA256, []byte("2222222222222222"), tagSize, variant, 0)
 			if err != nil {
 				t.Fatalf("got: %v, want: success", err)
 			}
@@ -287,7 +287,7 @@ func TestAEADWithAssociatedDataSlice(t *testing.T) {
 	const tagSize = 16
 	for _, variant := range []aesctrhmac.Variant{aesctrhmac.VariantNoPrefix, aesctrhmac.VariantTink, aesctrhmac.VariantCrunchy} {
 		t.Run(variant.String(), func(t *testing.T) {
-			cipher, err := createAEAD([]byte("1111111111111111"), ivSize, aesctrhmac.SHA1, []byte("2222222222222222"), tagSize, variant, 0)
+			cipher, err := createAEAD([]byte("1111111111111111"), ivSize, aesctrhmac.SHA256, []byte("2222222222222222"), tagSize, variant, 0)
 			if err != nil {
 				t.Fatalf("got: %v, want: success", err)
 			}
@@ -311,7 +311,7 @@ func TestAEADEncryptDecryptRandomMessage(t *testing.T) {
 	const tagSize = 16
 	for _, variant := range []aesctrhmac.Variant{aesctrhmac.VariantNoPrefix, aesctrhmac.VariantTink, aesctrhmac.VariantCrunchy} {
 		t.Run(variant.String(), func(t *testing.T) {
-			cipher, err := createAEAD([]byte("1111111111111111"), ivSize, aesctrhmac.SHA1, []byte("2222222222222222"), tagSize, aesctrhmac.VariantTink, 0)
+			cipher, err := createAEAD([]byte("1111111111111111"), ivSize, aesctrhmac.SHA256, []byte("2222222222222222"), tagSize, aesctrhmac.VariantTink, 0)
 			if err != nil {
 				t.Fatalf("got: %v, want: success", err)
 			}

--- a/aead/aesgcm/aead.go
+++ b/aead/aesgcm/aead.go
@@ -22,16 +22,15 @@ import (
 
 	"github.com/tink-crypto/tink-go/v2/insecuresecretdataaccess"
 	"github.com/tink-crypto/tink-go/v2/internal/aead"
-	"github.com/tink-crypto/tink-go/v2/internal/random"
 	"github.com/tink-crypto/tink-go/v2/key"
 	"github.com/tink-crypto/tink-go/v2/tink"
 )
 
 const (
 	// ivSize is the acceptable IV size defined by RFC 5116.
-	ivSize = 12
+	defaultIvSize = 12
 	// tagSize is the acceptable tag size defined by RFC 5116.
-	tagSize = 16
+	defaultTagSize = 16
 )
 
 // fullAEAD is an implementation of the [tink.AEAD] interface with AES-GCM.
@@ -54,13 +53,13 @@ var _ tink.AEAD = (*fullAEAD)(nil)
 // where prefix is the key's output prefix, iv is a random 12-byte IV,
 // ciphertext is the encrypted plaintext, and tag is a 16-byte tag.
 func (a *fullAEAD) Encrypt(plaintext, associatedData []byte) ([]byte, error) {
+	tagSize := a.cipher.Overhead()
 	if err := aead.CheckAESGCMPlaintextSize(uint64(len(plaintext))); err != nil {
 		return nil, fmt.Errorf("aesgcm.Encrypt: %v", err)
 	}
-	dst := make([]byte, len(a.prefix)+ivSize, len(a.prefix)+ivSize+len(plaintext)+tagSize)
+	dst := make([]byte, len(a.prefix), len(a.prefix)+len(plaintext)+tagSize)
 	copy(dst, a.prefix)
 	iv := dst[len(a.prefix):]
-	random.MustRand(iv)
 	return a.cipher.Seal(dst, iv, plaintext, associatedData), nil
 }
 
@@ -74,6 +73,9 @@ func (a *fullAEAD) Encrypt(plaintext, associatedData []byte) ([]byte, error) {
 // the encrypted plaintext, and tag is the 16-byte tag.
 // prefix must match the key's output prefix. The prefix may be empty.
 func (a *fullAEAD) Decrypt(ciphertext, associatedData []byte) ([]byte, error) {
+	ivSize := a.cipher.NonceSize()
+	tagSize := a.cipher.Overhead()
+
 	if len(ciphertext) < len(a.prefix)+ivSize+tagSize {
 		return nil, fmt.Errorf("aesgcm.Decrypt: ciphertext with size %d is too short", len(ciphertext))
 	}
@@ -97,17 +99,17 @@ func NewAEAD(k *Key) (tink.AEAD, error) {
 	if err := aead.ValidateAESKeySize(uint32(k.parameters.KeySizeInBytes())); err != nil {
 		return nil, fmt.Errorf("aesgcm.NewAEAD: %v", err)
 	}
-	if k.parameters.IVSizeInBytes() != ivSize {
-		return nil, fmt.Errorf("aesgcm.NewAEAD: unsupported IV size: got %v, want %v", k.parameters.IVSizeInBytes(), ivSize)
+	if k.parameters.IVSizeInBytes() != defaultIvSize {
+		return nil, fmt.Errorf("aesgcm.NewAEAD: unsupported IV size: got %v, want %v", k.parameters.IVSizeInBytes(), defaultIvSize)
 	}
-	if k.parameters.TagSizeInBytes() != tagSize {
-		return nil, fmt.Errorf("aesgcm.NewAEAD: unsupported tag size: got %v, want %v", k.parameters.TagSizeInBytes(), tagSize)
+	if k.parameters.TagSizeInBytes() != defaultTagSize {
+		return nil, fmt.Errorf("aesgcm.NewAEAD: unsupported tag size: got %v, want %v", k.parameters.TagSizeInBytes(), defaultTagSize)
 	}
 	c, err := aes.NewCipher(k.KeyBytes().Data(insecuresecretdataaccess.Token{}))
 	if err != nil {
 		return nil, fmt.Errorf("aesgcm.NewAEAD: failed to initialize cipher")
 	}
-	aeadCipher, err := cipher.NewGCM(c)
+	aeadCipher, err := cipher.NewGCMWithRandomNonce(c)
 	if err != nil {
 		return nil, fmt.Errorf("aesgcm.NewAEAD: failed to create cipher.AEAD")
 	}

--- a/aead/subtle/encrypt_then_authenticate_test.go
+++ b/aead/subtle/encrypt_then_authenticate_test.go
@@ -160,7 +160,7 @@ func TestETAEncryptDecrypt(t *testing.T) {
 	const macKeySize = 16
 	const tagSize = 16
 
-	cipher, err := createAEAD(keySize, ivSize, "SHA1", macKeySize, tagSize)
+	cipher, err := createAEAD(keySize, ivSize, "SHA256", macKeySize, tagSize)
 	if err != nil {
 		t.Fatalf("got: %v, want: success", err)
 	}
@@ -192,7 +192,7 @@ func TestETAWithAssociatedDataSlice(t *testing.T) {
 	const ivSize = 12
 	const macKeySize = 16
 	const tagSize = 16
-	cipher, err := createAEAD(keySize, ivSize, "SHA1", macKeySize, tagSize)
+	cipher, err := createAEAD(keySize, ivSize, "SHA256", macKeySize, tagSize)
 	if err != nil {
 		t.Fatalf("got: %v, want: success", err)
 	}
@@ -218,7 +218,7 @@ func TestETAEncryptDecryptRandomMessage(t *testing.T) {
 	const macKeySize = 16
 	const tagSize = 16
 
-	cipher, err := createAEAD(keySize, ivSize, "SHA1", macKeySize, tagSize)
+	cipher, err := createAEAD(keySize, ivSize, "SHA256", macKeySize, tagSize)
 	if err != nil {
 		t.Fatalf("got: %v, want: success", err)
 	}
@@ -253,7 +253,7 @@ func TestETAMultipleEncrypt(t *testing.T) {
 	const macKeySize = 16
 	const tagSize = 16
 
-	cipher, err := createAEAD(keySize, ivSize, "SHA1", macKeySize, tagSize)
+	cipher, err := createAEAD(keySize, ivSize, "SHA256", macKeySize, tagSize)
 	if err != nil {
 		t.Fatalf("got: %v, want: success", err)
 	}
@@ -282,7 +282,7 @@ func TestETAInvalidTagSize(t *testing.T) {
 	const macKeySize = 16
 	const tagSize = 9 // Invalid!
 
-	if _, err := createAEAD(keySize, ivSize, "SHA1", macKeySize, tagSize); err == nil {
+	if _, err := createAEAD(keySize, ivSize, "SHA256", macKeySize, tagSize); err == nil {
 		t.Error("got: success, want: error invalid tag size")
 	}
 }
@@ -293,7 +293,7 @@ func TestETADecryptModifiedCiphertext(t *testing.T) {
 	const macKeySize = 16
 	const tagSize = 16
 
-	cipher, err := createAEAD(keySize, ivSize, "SHA1", macKeySize, tagSize)
+	cipher, err := createAEAD(keySize, ivSize, "SHA256", macKeySize, tagSize)
 	if err != nil {
 		t.Fatalf("got: %v, want: success", err)
 	}
@@ -356,7 +356,7 @@ func TestETAEmptyParams(t *testing.T) {
 	const macKeySize = 16
 	const tagSize = 16
 
-	cipher, err := createAEAD(keySize, ivSize, "SHA1", macKeySize, tagSize)
+	cipher, err := createAEAD(keySize, ivSize, "SHA256", macKeySize, tagSize)
 	if err != nil {
 		t.Fatalf("got: %v, want: success", err)
 	}

--- a/aead/xaesgcm/aead.go
+++ b/aead/xaesgcm/aead.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	ivSize  = 12
-	tagSize = 16
+	ivSize  = 0
+	tagSize = 28
 
 	intSize = 32 << (^uint(0) >> 63) // 32 or 64
 	maxInt  = 1<<(intSize-1) - 1
@@ -87,7 +87,7 @@ func newAESGCMCipher(key []byte) (cipher.AEAD, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize cipher")
 	}
-	aesGCM, err := cipher.NewGCM(c)
+	aesGCM, err := cipher.NewGCMWithRandomNonce(c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cipher.AEAD")
 	}

--- a/docs/FIPS.md
+++ b/docs/FIPS.md
@@ -1,0 +1,19 @@
+# FIPS-140 compliance
+
+Tink's Go implementation doesn't have its own FIPS-140 CMVP certification, but
+in many cases it wraps FIPS-certified components of the Go standard library.
+Some portions of this library work with the debug setting `GODEBUG=fips140=only`
+enabled, which causes non-FIPS-compliant uses of the standard library
+cryptographic module to return errors or panic.
+
+## AEAD
+
+AEAD runs in FIPS-140-enforcing mode with the following key templates:
+
+- AES128CTRHMACSHA256
+- AES128GCM
+- AES128GCMNoPrefix
+- AES245CTRHMACSHA256
+- AES256GCM
+- XAES256GCM160BitNonce
+- XAES256GCM192BitNonce


### PR DESCRIPTION
In this merge request I've modified the `aead`  package and its subpackages so that as many of the tests as possible pass when running with `GOFIPS140=latest` and `GODEBUG=fips140=only`.

Where tests do not pass under those conditions, I've added a `noFIPS` member to the test element so that test authors can omit it normally and its inclusion provides a convenient place for a comment describing why the test won't pass in FIPS-enforcing mode, and I have modified the table-driven test loop to skip those tests with `noFIPS` set if `crypto/fips140.Enabled()` returns true.

The result is that `GOFIPS140=latest GODEBUG=fips140=only go test ./aead/...` passes, while running tests without either of those variables set still executes the full suite of tests including those with expected failures under FIPS-enforcing mode.

Strictly speaking, a grey area exists where the test checks for the FIPS module being selected, not FIPS enforcement. Tink appears to currently target Go 1.24, and the `fips140.Enforcing()` check didn't exist until Go 1.26. As a result, the full suite of tests only runs with the FIPS module fully disabled (which is the default) even though they could technically pass with it enabled but not enforcing.

I have additional work on other packages that I also intend to submit. I can update this PR to include those changes, or I can submit those changes separately.