### PR TITLE
mldsa: fix centeredAbs at (q-1)/2 and add the CCTV accumulated tests

### DIFF
--- a/internal/signature/mldsa/algebra.go
+++ b/internal/signature/mldsa/algebra.go
@@ -194,11 +194,21 @@ func (a rZq) useHint(gamma2 uint32, h rZq) rZq {
 
 func (a rZq) centeredAbs() uint32 {
 	// Constant time version of the following logic:
-	// if (q-1)/2 <= a {
+	// if (q-1)/2 < a {
 	// 	return uint32(q - a)
 	// }
 	// return uint32(a)
-	c := subtle.ConstantTimeLessOrEq((q-1)/2, int(a))
+	//
+	// FIPS 204 §2.3 defines a mod± α as the unique m' ∈ ℤ with
+	//   m' ≡ m (mod α) and -⌈α/2⌉ < m' ≤ ⌊α/2⌋.
+	// q = 8380417 is odd, so ⌊q/2⌋ = (q-1)/2 = 4190208 and ⌈q/2⌉ = (q+1)/2 =
+	// 4190209, giving -4190208 ≤ m' ≤ 4190208, i.e. m' ∈ [-(q-1)/2, (q-1)/2].
+	// For a ∈ [0, q):
+	//   a ≤ ⌊q/2⌋ = (q-1)/2  ⟹  m' = a, |m'| = a
+	//   a > ⌊q/2⌋ = (q-1)/2  ⟹  m' = a − q, |m'| = q − a
+	// So the predicate for the q − a branch is a > (q-1)/2; the boundary
+	// value a = (q-1)/2 is non-negative and stays in the +a branch.
+	c := subtle.ConstantTimeLessOrEq((q-1)/2+1, int(a))
 	return uint32(subtle.ConstantTimeSelect(c, int(q-a), int(a)))
 }
 

--- a/internal/signature/mldsa/algebra_test.go
+++ b/internal/signature/mldsa/algebra_test.go
@@ -164,7 +164,7 @@ func TestCenteredAbs(t *testing.T) {
 	for i := 0; i < q; i++ {
 		num := rZq(i)
 		exp := uint32(num)
-		if (q-1)/2 <= exp {
+		if (q-1)/2 < exp {
 			exp = q - exp
 		}
 		got := num.centeredAbs()

--- a/internal/signature/mldsa/cctv_test.go
+++ b/internal/signature/mldsa/cctv_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mldsa
+
+import (
+	"encoding/hex"
+	"strconv"
+	"testing"
+
+	"golang.org/x/crypto/sha3"
+)
+
+// CCTV accumulated test vectors.
+// See https://github.com/C2SP/CCTV/tree/main/ML-DSA/accumulated.
+
+// TestCCTVAccumulated applies the CCTV accumulated random key generation +
+// signature vectors. Seeds are drawn from one SHAKE128 instance and the
+// derived public key plus the deterministic signature of an empty message
+// are absorbed into a second SHAKE128 instance; the squeezed 32-byte
+// output is the test value.
+//
+// The 60 000 000-iteration vectors take several CPU-hours per parameter
+// set and are not included.
+func TestCCTVAccumulated(t *testing.T) {
+	vectors := []struct {
+		name       string
+		params     *params
+		iterations int
+		expected   string
+	}{
+		{"ML-DSA-44/100", MLDSA44, 100, "d51148e1f9f4fa1a723a6cf42e25f2a99eb5c1b378b3d2dbbd561b1203beeae4"},
+		{"ML-DSA-44/10000", MLDSA44, 10000, "e7fd21f6a59bcba60d65adc44404bb29a7c00e5d8d3ec06a732c00a306a7d143"},
+		{"ML-DSA-65/100", MLDSA65, 100, "8358a1843220194417cadbc2651295cd8fc65125b5a5c1a239a16dc8b57ca199"},
+		{"ML-DSA-65/10000", MLDSA65, 10000, "5ff5e196f0b830c3b10a9eb5358e7c98a3a20136cb677f3ae3b90175c3ace329"},
+		{"ML-DSA-87/100", MLDSA87, 100, "8c3ad714777622b8f21ce31bb35f71394f23bc0fcf3c78ace5d608990f3b061b"},
+		{"ML-DSA-87/10000", MLDSA87, 10000, "80a8cf39317f7d0be0e24972c51ac152bd2a3e09bc0c32ce29dd82c4e7385e60"},
+	}
+	for _, v := range vectors {
+		t.Run(v.name, func(t *testing.T) {
+			if testing.Short() && v.iterations > 100 {
+				t.Skip("skipping long iteration vector in -short mode")
+			}
+			t.Parallel()
+			got := runCCTVAccumulated(v.params, v.iterations)
+			if got != v.expected {
+				t.Errorf("got %s, want %s", got, v.expected)
+			}
+		})
+	}
+}
+
+func runCCTVAccumulated(par *params, iterations int) string {
+	source := sha3.NewShake128()
+	acc := sha3.NewShake128()
+	var seed [SecretKeySeedSize]byte
+	for i := 0; i < iterations; i++ {
+		source.Read(seed[:])
+		pk, sk := par.KeyGenFromSeed(seed)
+		sig, err := sk.SignDeterministic(nil, nil)
+		if err != nil {
+			panic(err)
+		}
+		acc.Write(pk.Encode())
+		acc.Write(sig)
+	}
+	var out [32]byte
+	acc.Read(out[:])
+	return hex.EncodeToString(out[:])
+}
+
+// TestCCTVFieldOps applies the CCTV exhaustive field-operations vector.
+// For each r in [0, q), 12 newline-terminated ASCII decimals are absorbed
+// into a SHAKE128 instance: the centered mod q value, its absolute value,
+// the Power2Round (r1, r0) pair (with r0 in unsigned [0, q) form), and
+// then for each of the two γ₂ values the HighBits, UseHint(1, r),
+// LowBits (signed centered), and |LowBits|.
+func TestCCTVFieldOps(t *testing.T) {
+	// https://github.com/C2SP/CCTV/blob/main/ML-DSA/accumulated/README.md#field-operation-tests
+	const expected = "f930663417278156ab05d940294a77210a809c924d8ab63ec72f4526247602c7"
+
+	gammas := [2]uint32{MLDSA44.gamma2, MLDSA65.gamma2}
+	acc := sha3.NewShake128()
+	buf := make([]byte, 0, 256)
+	w := func(s int64) {
+		buf = strconv.AppendInt(buf, s, 10)
+		buf = append(buf, '\n')
+	}
+	// Reuse a single zeroed poly: by writing the value of interest into
+	// p[0] (and leaving the other 255 coefficients at 0), p.infinityNorm()
+	// returns the per-coefficient |·mod± q| of that value.
+	var p poly
+	infNorm := func(a rZq) uint32 {
+		p[0] = a
+		return p.infinityNorm()
+	}
+
+	for r := uint32(0); r < q; r++ {
+		a := rZq(r)
+		w(centeredMod(a))
+		w(int64(infNorm(a)))
+
+		// Power2Round's r0 is written in unsigned [0, q) form, which is
+		// what tink-go's power2Round already returns.
+		r1, r0 := a.power2Round()
+		w(int64(r1))
+		w(int64(r0))
+
+		for _, g := range gammas {
+			r1d, r0d := a.decompose(g)
+			w(int64(r1d))
+			w(int64(a.useHint(g, rZq(1))))
+			// Decompose's r0 is written in signed centered form.
+			w(centeredMod(r0d))
+			w(int64(infNorm(r0d)))
+		}
+
+		acc.Write(buf)
+		buf = buf[:0]
+	}
+
+	var out [32]byte
+	acc.Read(out[:])
+	if got := hex.EncodeToString(out[:]); got != expected {
+		t.Errorf("got %s, want %s", got, expected)
+	}
+}
+
+// centeredMod returns r mod± q as a signed integer, where q is odd so
+// the result is in [-(q-1)/2, (q-1)/2]. See FIPS 204 §2.3. tink-go
+// itself only ever needs |r mod± q| (centeredAbs), not the sign, so it
+// has no equivalent function to test directly.
+func centeredMod(a rZq) int64 {
+	if uint32(a) <= (q-1)/2 {
+		return int64(a)
+	}
+	return int64(a) - int64(q)
+}


### PR DESCRIPTION
## Summary

Two related changes:

1. **Bugfix:** `centeredAbs(a)` is off by one at `a = (q-1)/2`. q is odd,
   so per FIPS 204 §2.3 the centered representative of `(q-1)/2 = 4 190 208`
   is itself, not `q − a = 4 190 209`. The implementation used the
   inclusive predicate `(q-1)/2 <= a` to pick the `q − a` branch, and
   `TestCenteredAbs`'s expected-value computation has the same off-by-one
   so the test passed by being wrong in the same way as the implementation.

2. **New tests:** apply the [CCTV ML-DSA accumulated test
   vectors](https://github.com/C2SP/CCTV/tree/main/ML-DSA/accumulated).
   These capture randomized ML-DSA end-to-end results and exhaustive
   field-operation results, covering all the field edge cases.

## Impact of the bugfix

`centeredAbs` is consumed by `centeredMax` and from there by `infinityNorm`.
All four `infinityNorm` call sites (in `signInternalWithMu` and
`verifyInternalWithMu`) bound the input coefficients well below
`(q-1)/2`: `2^log2γ₁ + β`, `γ₂`, `τ·2^(d-1)`. So the off-by-one never
fires on honest inputs and **no signing/verifying path is functionally
affected**. The fix is for spec conformance and to remove a sharp edge
in `infinityNorm` if it's ever applied to a polynomial with arbitrary
coefficients in the future.

## Tests added

* `TestCCTVAccumulated` — accumulated random key-generation +
  deterministic signature vectors at 100 and 10 000 iterations for each
  of ML-DSA-44, -65, -87. The 10 000-iteration vectors are skipped in
  `-short` mode. Total runtime ~50 s without `-short`, ~1 s with it.
* `TestCCTVFieldOps` — the exhaustive field-operations vector,
  iterating every element of ℤq (8 380 417 inputs) and exercising
  `centeredAbs`, `centeredMax`, `infinityNorm`, `power2Round`,
  `decompose`, and `useHint` at every coefficient. This is the test
  that surfaced the `centeredAbs` bug above; it would also have caught
  the `useHint` r0 = 0 bug fixed in #48 (60 disagreeing inputs across
  the two γ₂ values), since `algebra_test.go`'s `TestUseHint`
  re-implemented the same off-by-one bug as the production code,
  whereas this test compares against an externally-derived hash.

## Test plan

- [x] `go test -count=1 ./internal/signature/mldsa/ ./signature/mldsa/`
- [x] `go test -short -count=1 ./internal/signature/mldsa/`
- [x] `TestCCTVFieldOps` produces
      `f930663417278156ab05d940294a77210a809c924d8ab63ec72f4526247602c7`
      (matches the published hash) only with the centeredAbs fix applied.
- [x] All six `TestCCTVAccumulated` vectors at 100 and 10 000 iterations
      match the published hashes for ML-DSA-44, -65 and -87.
- [x] Reverting the #48 useHint fix on top of this branch makes
      `TestCCTVFieldOps` fail (alongside the existing `algebra_test.go`'s
      now-corrected `TestUseHint`).

## References

- CCTV README: https://github.com/C2SP/CCTV/blob/main/ML-DSA/accumulated/README.md
- Sibling fix in this same area on tink-go main: #48 (UseHint at r0 = 0)
