### PR TITLE
security: enforce maximum ciphertext segment size to prevent OOM

### DIFF
--- a/streamingaead/aesgcmhkdf/parameters.go
+++ b/streamingaead/aesgcmhkdf/parameters.go
@@ -93,6 +93,11 @@ func validateOpts(opts *ParametersOpts) error {
 	if opts.SegmentSizeInBytes < minSegmentSize {
 		return fmt.Errorf("ciphertext segment size must be at least %d, got %d", minSegmentSize, opts.SegmentSizeInBytes)
 	}
+	// Prevent OOM by enforcing a maximum segment size (16MB).
+    const maxSegmentSize = 16 * 1024 * 1024
+    if opts.SegmentSizeInBytes > maxSegmentSize {
+        return fmt.Errorf("ciphertext segment size must be at most %d, got %d", maxSegmentSize, opts.SegmentSizeInBytes)
+    }
 	return nil
 }
 

--- a/streamingaead/aesgcmhkdf/parameters_test.go
+++ b/streamingaead/aesgcmhkdf/parameters_test.go
@@ -213,3 +213,15 @@ func TestParametersEqual_FalseIfDifferent(t *testing.T) {
 		})
 	}
 }
+
+func TestNewParameters_SegmentSizeTooLarge(t *testing.T) {
+	opts := aesgcmhkdf.ParametersOpts{
+		KeySizeInBytes:        32,
+		DerivedKeySizeInBytes: 32,
+		HKDFHashType:          aesgcmhkdf.SHA256,
+		SegmentSizeInBytes:    16*1024*1024 + 1, // 16MB + 1 byte (Sınırı aşan değer)
+	}
+	if _, err := aesgcmhkdf.NewParameters(opts); err == nil {
+		t.Errorf("aesgcmhkdf.NewParameters(%v) err = nil, want error for segment size > 16MB", opts)
+	}
+}


### PR DESCRIPTION
This PR addresses a pre-authentication Memory Exhaustion (OOM) vulnerability in the StreamingAEAD primitive. 

Currently, aesgcmhkdf.Parameters validates the minimum segment size but lacks an upper bound check. A malicious keyset configuration with an extremely large SegmentSizeInBytes (e.g., 1GB) triggers a massive heap allocation in the underlying noncebased.NewReader implementation before any integrity checks occur. 

This patch introduces a reasonable 16MB limit to ensure service stability and prevent Denial of Service attacks via resource exhaustion.