### PR TITLE
internal/jwk: add IsInt64 guard to PKCS1 RSA public exponent import

### DIFF
--- a/internal/jwk/jwk.go
+++ b/internal/jwk/jwk.go
@@ -218,9 +218,14 @@ func rsPublicKeyDataFromStruct(keyStruct *spb.Struct) (key.Key, error) {
 		kidStrategy = jwtrsassapkcs1.CustomKID
 	}
 
+	publicExponent := new(big.Int).SetBytes(rsaPubKey.exponent)
+	if !publicExponent.IsInt64() {
+		return nil, fmt.Errorf("public exponent cannot be represented as int64")
+	}
+
 	params, err := jwtrsassapkcs1.NewParameters(jwtrsassapkcs1.ParametersOpts{
 		ModulusSizeInBits: new(big.Int).SetBytes(rsaPubKey.modulus).BitLen(),
-		PublicExponent:    int(new(big.Int).SetBytes(rsaPubKey.exponent).Int64()),
+		PublicExponent:    int(publicExponent.Int64()),
 		Algorithm:         algorithm,
 		KidStrategy:       kidStrategy,
 	})

--- a/internal/jwk/jwk_test.go
+++ b/internal/jwk/jwk_test.go
@@ -71,6 +71,63 @@ func TestEd25519KeyConversion(t *testing.T) {
 	}
 }
 
+// n2048Base64 is a base64url-encoded 2048-bit RSA modulus used in tests.
+const n2048Base64 = "s1EKK81M5kTFtZSuUFnhKy8FS2WNXaWVmi_fGHG4CLw98-Yo0nkuUarVwSS0O9pFPcpc3kvPKOe9Tv-6DLS3Qru21aATy2PRqjqJ4CYn71OYtSwM_ZfSCKvrjXybzgu-sBmobdtYm-sppbdL-GEHXGd8gdQw8DDCZSR6-dPJFAzLZTCdB-Ctwe_RXPF-ewVdfaOGjkZIzDoYDw7n-OHnsYCYozkbTOcWHpjVevipR-IBpGPi1rvKgFnlcG6d_tj0hWRl_6cS7RqhjoiNEtxqoJzpXs_Kg8xbCxXbCchkf11STA8udiCjQWuWI8rcDwl69XMmHJjIQAqhKvOOQ8rYTQ"
+
+// TestRS256OversizedPublicExponentRejected verifies that a JWK with a
+// public exponent that cannot be represented as int64 is rejected when
+// importing an RS256 (PKCS1) key. This mirrors the existing check in the
+// PSS (PS256/PS384/PS512) import path and prevents silent truncation of
+// a malformed exponent via big.Int.Int64().
+//
+// The crafted exponent is 2^64 + 65537 (base64url: AQAAAAAAAQAB). Its
+// big.Int.Int64() value happens to equal 65537 (low-64-bit wrap-around),
+// so without the IsInt64 guard the import would silently succeed with the
+// truncated value instead of returning an error.
+func TestRS256OversizedPublicExponentRejected(t *testing.T) {
+	// "e" encodes 2^64 + 65537 (9 bytes: 0x010000000000010001).
+	// IsInt64() returns false; Int64() silently wraps to 65537.
+	jwkSet := `{
+		"keys":[
+			{
+				"kty":"RSA",
+				"alg":"RS256",
+				"n":"` + n2048Base64 + `",
+				"e":"AQAAAAAAAQAB",
+				"use":"sig",
+				"key_ops":["verify"]
+			}
+		]
+	}`
+
+	_, err := jwk.ToPublicKeysetHandle([]byte(jwkSet), jwk.Ed25519SupportNone)
+	if err == nil {
+		t.Fatal("ToPublicKeysetHandle() err = nil, want error for oversized public exponent")
+	}
+}
+
+// TestRS256NormalPublicExponentAccepted verifies that a well-formed RS256 JWK
+// with the standard exponent 65537 (base64url: AQAB) is imported successfully.
+func TestRS256NormalPublicExponentAccepted(t *testing.T) {
+	jwkSet := `{
+		"keys":[
+			{
+				"kty":"RSA",
+				"alg":"RS256",
+				"n":"` + n2048Base64 + `",
+				"e":"AQAB",
+				"use":"sig",
+				"key_ops":["verify"]
+			}
+		]
+	}`
+
+	_, err := jwk.ToPublicKeysetHandle([]byte(jwkSet), jwk.Ed25519SupportNone)
+	if err != nil {
+		t.Fatalf("ToPublicKeysetHandle() err = %v, want nil for valid RS256 key", err)
+	}
+}
+
 func TestEd25519KeyConversionNotSupported(t *testing.T) {
 	jwkSet := `{
 		"keys":[

--- a/internal/jwk/jwk_test.go
+++ b/internal/jwk/jwk_test.go
@@ -17,10 +17,10 @@ package jwk_test
 import (
 	"testing"
 
-	spb "google.golang.org/protobuf/types/known/structpb"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/protobuf/testing/protocmp"
 	"github.com/tink-crypto/tink-go/v2/internal/jwk"
+	"google.golang.org/protobuf/testing/protocmp"
+	spb "google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestEd25519KeyConversion(t *testing.T) {
@@ -72,6 +72,8 @@ func TestEd25519KeyConversion(t *testing.T) {
 }
 
 // n2048Base64 is a base64url-encoded 2048-bit RSA modulus used in tests.
+// Taken from:
+// https://github.com/C2SP/wycheproof/blob/cd27d6419bedd83cbd24611ec54b6d4bfdb0cdca/testvectors/rsa_pkcs1_2048_test.json#L13
 const n2048Base64 = "s1EKK81M5kTFtZSuUFnhKy8FS2WNXaWVmi_fGHG4CLw98-Yo0nkuUarVwSS0O9pFPcpc3kvPKOe9Tv-6DLS3Qru21aATy2PRqjqJ4CYn71OYtSwM_ZfSCKvrjXybzgu-sBmobdtYm-sppbdL-GEHXGd8gdQw8DDCZSR6-dPJFAzLZTCdB-Ctwe_RXPF-ewVdfaOGjkZIzDoYDw7n-OHnsYCYozkbTOcWHpjVevipR-IBpGPi1rvKgFnlcG6d_tj0hWRl_6cS7RqhjoiNEtxqoJzpXs_Kg8xbCxXbCchkf11STA8udiCjQWuWI8rcDwl69XMmHJjIQAqhKvOOQ8rYTQ"
 
 // TestRS256OversizedPublicExponentRejected verifies that a JWK with a
@@ -102,7 +104,7 @@ func TestRS256OversizedPublicExponentRejected(t *testing.T) {
 
 	_, err := jwk.ToPublicKeysetHandle([]byte(jwkSet), jwk.Ed25519SupportNone)
 	if err == nil {
-		t.Fatal("ToPublicKeysetHandle() err = nil, want error for oversized public exponent")
+		t.Errorf("ToPublicKeysetHandle() err = nil, want error for oversized public exponent")
 	}
 }
 
@@ -124,7 +126,7 @@ func TestRS256NormalPublicExponentAccepted(t *testing.T) {
 
 	_, err := jwk.ToPublicKeysetHandle([]byte(jwkSet), jwk.Ed25519SupportNone)
 	if err != nil {
-		t.Fatalf("ToPublicKeysetHandle() err = %v, want nil for valid RS256 key", err)
+		t.Errorf("ToPublicKeysetHandle() err = %v, want nil for valid RS256 key", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

The PSS RSA JWK import path (`psPublicKeyDataFromStruct`) already validates that the decoded public exponent fits in `int64` before calling `Int64()`. The PKCS1 path (`rsPublicKeyDataFromStruct`) was missing this guard, calling `Int64()` directly on the `*big.Int` — whose behavior is undefined (in practice: low-64-bit truncation) when the value exceeds `math.MaxInt64`.

**Inconsistency (before fix):**
```go
// PSS path — safe:
publicExponent := new(big.Int).SetBytes(rsaPubKey.exponent)
if !publicExponent.IsInt64() {
    return nil, fmt.Errorf("public exponent cannot be represented as int64")
}

// PKCS1 path — missing guard:
PublicExponent: int(new(big.Int).SetBytes(rsaPubKey.exponent).Int64()),
```

A JWK with `"e"` encoding `2^64 + 65537` (base64url: `AQAAAAAAAQAB`, 9 bytes) returns `false` from `IsInt64()`. The PSS path correctly returns an error; the PKCS1 path silently accepts the key, with `Int64()` wrapping to `65537` (the low 64 bits). The malformed JWK is imported without error rather than being rejected.

## Fix

Extract the `*big.Int`, check `IsInt64()`, then reuse it in `NewParameters` — matching the PSS path exactly.

## Tests

- `TestRS256OversizedPublicExponentRejected`: crafted `e = 2^64 + 65537` must be rejected with an error (fails before fix, passes after)
- `TestRS256NormalPublicExponentAccepted`: standard `e = 65537` (`AQAB`) must be accepted (regression guard)