### PR TITLE
Security: Cross-validate KeyMaterialType in NewHandleWithNoSecrets to prevent spoofing

### DIFF
--- a/keyset/handle.go
+++ b/keyset/handle.go
@@ -303,7 +303,37 @@ func NewHandleWithNoSecrets(ks *tinkpb.Keyset) (*Handle, error) {
 	if hasSecrets(ks) {
 		return nil, fmt.Errorf("keyset.Handle: importing unencrypted secret key material is forbidden")
 	}
-	return newKeysetHandleFromProto(ks)
+	handle, err := newKeysetHandleFromProto(ks)
+	if err != nil {
+		return nil, err
+	}
+	// Cross-validate: after parsing, re-serialize each key and verify the
+	// actual KeyMaterialType from the trusted parser matches the input.
+	// This prevents spoofing where an attacker sets key_material_type to
+	// ASYMMETRIC_PUBLIC for a symmetric key (e.g., HMAC) to bypass hasSecrets.
+	for i := 0; i < handle.Len(); i++ {
+		entry, err := handle.Entry(i)
+		if err != nil {
+			return nil, fmt.Errorf("keyset.Handle: %v", err)
+		}
+		// Check if the parsed key is actually a private key.
+		if _, ok := entry.Key().(privateKey); ok {
+			return nil, fmt.Errorf("keyset.Handle: keyset contains a private key despite key_material_type claiming otherwise")
+		}
+		// Re-serialize and check the trusted KeyMaterialType.
+		protoKeySerialization, err := protoserialization.SerializeKey(entry.Key())
+		if err != nil {
+			return nil, fmt.Errorf("keyset.Handle: cannot verify key material type: %v", err)
+		}
+		trustedType := protoKeySerialization.KeyData().GetKeyMaterialType()
+		switch trustedType {
+		case tinkpb.KeyData_UNKNOWN_KEYMATERIAL, tinkpb.KeyData_ASYMMETRIC_PRIVATE, tinkpb.KeyData_SYMMETRIC:
+			return nil, fmt.Errorf(
+				"keyset.Handle: key material type mismatch: serialized key_material_type was spoofed; "+
+					"actual type from parser is %v", trustedType)
+		}
+	}
+	return handle, nil
 }
 
 // Read tries to create a Handle from an encrypted keyset obtained via reader.


### PR DESCRIPTION
## Summary

Fix `NewHandleWithNoSecrets` / `ReadWithNoSecrets` to cross-validate the actual `KeyMaterialType` after parsing, preventing attackers from importing symmetric secret key material by spoofing `key_material_type` to `ASYMMETRIC_PUBLIC`.

## Vulnerability (Issue #43)

`hasSecrets()` trusts the serialized `KeyData.key_material_type` enum to decide whether a keyset contains secret material. This field is attacker-controlled in the input bytes.

**Attack path:**
1. Serialize a `tinkpb.Keyset` containing an HMAC key with attacker-chosen key bytes
2. Set `KeyData.key_material_type` to `ASYMMETRIC_PUBLIC`
3. Load through `ReadWithNoSecrets` or `NewHandleWithNoSecrets`
4. `hasSecrets()` accepts because it only checks the spoofed enum
5. HMAC parser accepts the key, `mac.New(handle)` returns a working primitive
6. Attacker now has a handle with known symmetric key material enabling **tag forgery**

## Fix

After parsing keys via `newKeysetHandleFromProto`, re-serialize each parsed key through the trusted serializer and verify the actual `KeyMaterialType`. Also check if any parsed key implements the `privateKey` interface. If any key's trusted type indicates secret material, reject the keyset with an error.

This is a defense-in-depth approach — the trusted parser knows the real key type regardless of what the attacker claimed in the serialized enum.

## Impact

Callers using `ReadWithNoSecrets` / `NewHandleWithNoSecrets` as a trust boundary for importing externally-provided "public" keysets can be tricked into accepting symmetric key material. For HMAC, this enables tag forgery for any authentication signal derived from that MAC.

Fixes #43
