### PR TITLE
streamingaead: lazily allocate segment buffers in Reader and Writer

### DIFF
--- a/streamingaead/streamingaead_benchmark_test.go
+++ b/streamingaead/streamingaead_benchmark_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 
 	"github.com/tink-crypto/tink-go/v2/keyset"
+	tinkpb "github.com/tink-crypto/tink-go/v2/proto/tink_go_proto"
 	"github.com/tink-crypto/tink-go/v2/streamingaead"
 	"github.com/tink-crypto/tink-go/v2/subtle/random"
-	tinkpb "github.com/tink-crypto/tink-go/v2/proto/tink_go_proto"
 )
 
 // Benchmarks for Steaming AEAD algorithms.
@@ -133,6 +133,145 @@ func BenchmarkEncryptDecrypt(b *testing.B) {
 					b.Fatalf(
 						"want that buffer to uses at most %d memory, but it now has capacity %d",
 						ciphertextBufferSize, cap(buffer.Bytes()))
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkDecryptSmallPayload measures decryption of payloads much smaller
+// than the ciphertext segment size, as in envelope encryption of many small
+// records. It isolates the per-reader setup and decryption cost, which for
+// small payloads is not amortized over a large stream.
+func BenchmarkDecryptSmallPayload(b *testing.B) {
+	const (
+		payloadSize        = 300
+		associatedDataSize = 256
+	)
+
+	testCases := []struct {
+		name     string
+		template *tinkpb.KeyTemplate
+	}{
+		{
+			name:     "AES128_GCM_HKDF_4KB",
+			template: streamingaead.AES128GCMHKDF4KBKeyTemplate(),
+		}, {
+			name:     "AES128_GCM_HKDF_1MB",
+			template: streamingaead.AES128GCMHKDF1MBKeyTemplate(),
+		}, {
+			name:     "AES256_GCM_HKDF_4KB",
+			template: streamingaead.AES256GCMHKDF4KBKeyTemplate(),
+		}, {
+			name:     "AES256_GCM_HKDF_1MB",
+			template: streamingaead.AES256GCMHKDF1MBKeyTemplate(),
+		}, {
+			name:     "AES256_CTR_HMAC_SHA256_1MB",
+			template: streamingaead.AES256CTRHMACSHA256Segment1MBKeyTemplate(),
+		},
+	}
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			handle, err := keyset.NewHandle(tc.template)
+			if err != nil {
+				b.Fatal(err)
+			}
+			primitive, err := streamingaead.New(handle)
+			if err != nil {
+				b.Fatal(err)
+			}
+			plaintext := random.GetRandomBytes(payloadSize)
+			associatedData := random.GetRandomBytes(associatedDataSize)
+
+			var ciphertext bytes.Buffer
+			w, err := primitive.NewEncryptingWriter(&ciphertext, associatedData)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if _, err := w.Write(plaintext); err != nil {
+				b.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				r, err := primitive.NewDecryptingReader(bytes.NewReader(ciphertext.Bytes()), associatedData)
+				if err != nil {
+					b.Fatal(err)
+				}
+				decrypted, err := io.ReadAll(r)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(decrypted) != payloadSize {
+					b.Fatalf("len(decrypted) = %d, want %d", len(decrypted), payloadSize)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkEncryptSmallPayload measures encryption of payloads much smaller
+// than the plaintext segment size, as in envelope encryption of many small
+// records. It isolates the per-writer setup and encryption cost, which for
+// small payloads is not amortized over a large stream.
+func BenchmarkEncryptSmallPayload(b *testing.B) {
+	const (
+		payloadSize        = 300
+		associatedDataSize = 256
+	)
+
+	testCases := []struct {
+		name     string
+		template *tinkpb.KeyTemplate
+	}{
+		{
+			name:     "AES128_GCM_HKDF_4KB",
+			template: streamingaead.AES128GCMHKDF4KBKeyTemplate(),
+		}, {
+			name:     "AES128_GCM_HKDF_1MB",
+			template: streamingaead.AES128GCMHKDF1MBKeyTemplate(),
+		}, {
+			name:     "AES256_GCM_HKDF_4KB",
+			template: streamingaead.AES256GCMHKDF4KBKeyTemplate(),
+		}, {
+			name:     "AES256_GCM_HKDF_1MB",
+			template: streamingaead.AES256GCMHKDF1MBKeyTemplate(),
+		}, {
+			name:     "AES256_CTR_HMAC_SHA256_1MB",
+			template: streamingaead.AES256CTRHMACSHA256Segment1MBKeyTemplate(),
+		},
+	}
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			handle, err := keyset.NewHandle(tc.template)
+			if err != nil {
+				b.Fatal(err)
+			}
+			primitive, err := streamingaead.New(handle)
+			if err != nil {
+				b.Fatal(err)
+			}
+			plaintext := random.GetRandomBytes(payloadSize)
+			associatedData := random.GetRandomBytes(associatedDataSize)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				w, err := primitive.NewEncryptingWriter(io.Discard, associatedData)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := w.Write(plaintext); err != nil {
+					b.Fatal(err)
+				}
+				if err := w.Close(); err != nil {
+					b.Fatal(err)
 				}
 			}
 		})

--- a/streamingaead/subtle/noncebased/noncebased.go
+++ b/streamingaead/subtle/noncebased/noncebased.go
@@ -98,8 +98,12 @@ type Writer struct {
 	noncePrefix                  []byte
 	plaintext                    []byte
 	plaintextPos                 int
-	ciphertext                   []byte
-	closed                       bool
+	// plaintextBufferLimit is the full plaintext segment size. w.plaintext
+	// starts small and grows toward this limit only if data actually
+	// arrives.
+	plaintextBufferLimit int
+	ciphertext           []byte
+	closed               bool
 }
 
 // WriterParams contains the options for instantiating a Writer via NewWriter().
@@ -146,7 +150,13 @@ func NewWriter(params WriterParams) (*Writer, error) {
 		nonceSize:                    params.NonceSize,
 		noncePrefix:                  params.NoncePrefix,
 		firstCiphertextSegmentOffset: params.FirstCiphertextSegmentOffset,
-		plaintext:                    make([]byte, params.PlaintextSegmentSize),
+
+		// The buffer must be able to hold a full plaintext segment, but is
+		// allocated small and grown as data actually arrives, so that
+		// plaintexts much smaller than the segment size do not pay for a
+		// full segment-sized allocation.
+		plaintext:            make([]byte, initialSegmentBufferSize(params.PlaintextSegmentSize)),
+		plaintextBufferLimit: params.PlaintextSegmentSize,
 	}, nil
 }
 
@@ -158,15 +168,36 @@ func (w *Writer) Write(p []byte) (int, error) {
 
 	pos := 0
 	for {
-		ptLim := len(w.plaintext)
+		ptLim := w.plaintextBufferLimit
 		if w.encryptedSegmentCnt == 0 {
+			if w.firstCiphertextSegmentOffset < 0 || w.firstCiphertextSegmentOffset > w.plaintextBufferLimit {
+				// A FirstCiphertextSegmentOffset outside the interval
+				// [0, PlaintextSegmentSize] cannot yield a valid first
+				// segment. The keyset-based streamingaead API never
+				// constructs such a Writer, but the exported subtle
+				// constructors only bound the offset from above.
+				return pos, errors.New("first ciphertext segment offset out of range")
+			}
 			ptLim -= w.firstCiphertextSegmentOffset
 		}
-		n := copy(w.plaintext[w.plaintextPos:ptLim], p[pos:])
+		copyLim := min(ptLim, len(w.plaintext))
+		n := copy(w.plaintext[w.plaintextPos:copyLim], p[pos:])
 		w.plaintextPos += n
 		pos += n
 		if pos == len(p) {
 			break
+		}
+
+		if w.plaintextPos < ptLim {
+			// The buffer is full but the segment is not complete: grow
+			// toward the full segment size, no less than the buffered data
+			// plus the data still pending in p, so that a single large
+			// Write skips the intermediate growth steps.
+			needed := w.plaintextPos + len(p) - pos
+			grown := make([]byte, grownSegmentBufferSize(len(w.plaintext), needed, w.plaintextBufferLimit))
+			copy(grown, w.plaintext[:w.plaintextPos])
+			w.plaintext = grown
+			continue
 		}
 
 		nonce, err := generateSegmentNonce(w.nonceSize, w.noncePrefix, w.encryptedSegmentCnt, false)
@@ -257,6 +288,10 @@ type Reader struct {
 	ciphertext                   []byte
 	ciphertextPos                int
 	lastSegmentDecrypted         bool
+	// ciphertextBufferLimit is the full segment buffer size
+	// (CiphertextSegmentSize + 1 lookahead byte). r.ciphertext starts small
+	// and grows toward this limit only if bytes actually arrive.
+	ciphertextBufferLimit int
 }
 
 // ReaderParams contains the options for instantiating a Reader via NewReader().
@@ -302,8 +337,12 @@ func NewReader(params ReaderParams) (*Reader, error) {
 		noncePrefix:                  params.NoncePrefix,
 		firstCiphertextSegmentOffset: params.FirstCiphertextSegmentOffset,
 
-		// Allocate an extra byte to detect the last segment.
-		ciphertext: make([]byte, params.CiphertextSegmentSize+1),
+		// The buffer must be able to hold a full segment plus an extra byte
+		// to detect the last segment, but is allocated small and grown as
+		// bytes actually arrive, so that plaintexts much smaller than the
+		// segment size do not pay for a full segment-sized allocation.
+		ciphertext:            make([]byte, initialSegmentBufferSize(params.CiphertextSegmentSize+1)),
+		ciphertextBufferLimit: params.CiphertextSegmentSize + 1,
 	}, nil
 }
 
@@ -321,11 +360,18 @@ func (r *Reader) Read(p []byte) (int, error) {
 	r.plaintext = r.plaintext[:0]
 	r.plaintextPos = 0
 
-	ctLim := len(r.ciphertext)
+	ctLim := r.ciphertextBufferLimit
 	if r.decryptedSegmentCnt == 0 {
 		ctLim -= r.firstCiphertextSegmentOffset
+		if ctLim > r.ciphertextBufferLimit {
+			// A negative FirstCiphertextSegmentOffset would require reading
+			// more bytes than the segment buffer can hold. The keyset-based
+			// streamingaead API never constructs such a Reader, but the
+			// exported subtle constructors only bound the offset from above.
+			return 0, ErrCiphertextSegmentTooShort
+		}
 	}
-	n, err := io.ReadFull(r.r, r.ciphertext[r.ciphertextPos:ctLim])
+	n, err := r.readSegmentGrowing(ctLim)
 	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
 		return 0, err
 	}
@@ -371,6 +417,87 @@ func (r *Reader) Read(p []byte) (int, error) {
 	n = copy(p, r.plaintext)
 	r.plaintextPos = n
 	return n, nil
+}
+
+// readSegmentGrowing reads into r.ciphertext[r.ciphertextPos:ctLim], growing
+// r.ciphertext toward the full segment buffer size as the stream proves to
+// have more data than the current buffer. ctLim must not exceed
+// r.ciphertextBufferLimit; Read guarantees this. It is semantically identical
+// to
+//
+//	io.ReadFull(r.r, r.ciphertext[r.ciphertextPos:ctLim])
+//
+// with a fully pre-allocated buffer: it returns the number of bytes read,
+// io.EOF if no bytes were read, and io.ErrUnexpectedEOF if the stream ended
+// after some bytes but before ctLim was reached.
+//
+// Throughout, end is the index one past the last buffered ciphertext byte,
+// and each read fills r.ciphertext[end:] up to ctLim or the current buffer
+// size, whichever is smaller. The loop and the error classification
+// otherwise mirror io.ReadAtLeast.
+func (r *Reader) readSegmentGrowing(ctLim int) (int, error) {
+	start := r.ciphertextPos
+	end := start
+	var err error
+	for end < ctLim && err == nil {
+		if end == len(r.ciphertext) {
+			// The buffer is full but the segment is not complete: grow
+			// toward the full segment buffer size. Unlike the Writer, the
+			// Reader never knows how much data is still pending.
+			grown := make([]byte, grownSegmentBufferSize(len(r.ciphertext), 0, r.ciphertextBufferLimit))
+			copy(grown, r.ciphertext[:end])
+			r.ciphertext = grown
+		}
+		readLim := min(len(r.ciphertext), ctLim)
+		var m int
+		m, err = r.r.Read(r.ciphertext[end:readLim])
+		end += m
+	}
+	if end >= ctLim {
+		err = nil
+	} else if end > start && err == io.EOF {
+		err = io.ErrUnexpectedEOF
+	}
+	return end - start, err
+}
+
+// initialSegmentBufferSize returns the initial allocation size for a segment
+// buffer: small, unless the full segment buffer is smaller still.
+func initialSegmentBufferSize(limit int) int {
+	const initial = 4096
+	if limit < initial {
+		return limit
+	}
+	return initial
+}
+
+// grownSegmentBufferSize returns the next size for a segment buffer of size
+// cur that must grow toward limit: cur multiplied by the growth factor, but
+// no smaller than needed, and limit itself once the chosen size would reach
+// at least three quarters of it. needed is the number of buffered and
+// pending bytes already known to the caller, or zero when unknown: a caller
+// holding more data than a growth step covers allocates for that data in one
+// step instead of paying for the intermediate steps. The large factor and
+// the final jump bound the number of reallocations and the memory traffic of
+// growth for segment-sized streams, and the jump also prevents a
+// nearly-full-sized step, such as one covering all but the Reader's one-byte
+// lookahead. The thresholds are arranged so that the multiplication cannot
+// overflow: it is taken only when the result is below three quarters of
+// limit.
+func grownSegmentBufferSize(cur, needed, limit int) int {
+	const growthFactor = 8
+	jumpThreshold := limit - limit/4
+	newSize := limit
+	if cur < jumpThreshold/growthFactor {
+		newSize = cur * growthFactor
+	}
+	if needed > newSize {
+		newSize = needed
+	}
+	if newSize >= jumpThreshold {
+		newSize = limit
+	}
+	return newSize
 }
 
 // generateSegmentNonce returns a nonce for a segment.

--- a/streamingaead/subtle/noncebased/noncebased.go
+++ b/streamingaead/subtle/noncebased/noncebased.go
@@ -98,8 +98,12 @@ type Writer struct {
 	noncePrefix                  []byte
 	plaintext                    []byte
 	plaintextPos                 int
-	ciphertext                   []byte
-	closed                       bool
+	// plaintextBufferLimit is the full plaintext segment size. w.plaintext
+	// starts small and grows toward this limit only if data actually
+	// arrives.
+	plaintextBufferLimit int
+	ciphertext           []byte
+	closed               bool
 }
 
 // WriterParams contains the options for instantiating a Writer via NewWriter().
@@ -146,7 +150,13 @@ func NewWriter(params WriterParams) (*Writer, error) {
 		nonceSize:                    params.NonceSize,
 		noncePrefix:                  params.NoncePrefix,
 		firstCiphertextSegmentOffset: params.FirstCiphertextSegmentOffset,
-		plaintext:                    make([]byte, params.PlaintextSegmentSize),
+
+		// The buffer must be able to hold a full plaintext segment, but is
+		// allocated small and grown as data actually arrives, so that
+		// plaintexts much smaller than the segment size do not pay for a
+		// full segment-sized allocation.
+		plaintext:            make([]byte, initialSegmentBufferSizeFor(params.PlaintextSegmentSize)),
+		plaintextBufferLimit: params.PlaintextSegmentSize,
 	}, nil
 }
 
@@ -158,15 +168,36 @@ func (w *Writer) Write(p []byte) (int, error) {
 
 	pos := 0
 	for {
-		ptLim := len(w.plaintext)
+		ptLim := w.plaintextBufferLimit
 		if w.encryptedSegmentCnt == 0 {
+			if w.firstCiphertextSegmentOffset < 0 || w.firstCiphertextSegmentOffset > w.plaintextBufferLimit {
+				// A FirstCiphertextSegmentOffset outside the interval
+				// [0, PlaintextSegmentSize] cannot yield a valid first
+				// segment. The keyset-based streamingaead API never
+				// constructs such a Writer, but the exported subtle
+				// constructors only bound the offset from above.
+				return pos, errors.New("first ciphertext segment offset out of range")
+			}
 			ptLim -= w.firstCiphertextSegmentOffset
 		}
-		n := copy(w.plaintext[w.plaintextPos:ptLim], p[pos:])
+		copyLim := min(ptLim, len(w.plaintext))
+		n := copy(w.plaintext[w.plaintextPos:copyLim], p[pos:])
 		w.plaintextPos += n
 		pos += n
 		if pos == len(p) {
 			break
+		}
+
+		if w.plaintextPos < ptLim {
+			// The buffer is full but the segment is not complete: grow
+			// toward the full segment size, no less than the buffered data
+			// plus the data still pending in p, so that a single large
+			// Write skips the intermediate growth steps.
+			needed := w.plaintextPos + len(p) - pos
+			grown := make([]byte, grownSegmentBufferSize(len(w.plaintext), needed, w.plaintextBufferLimit))
+			copy(grown, w.plaintext[:w.plaintextPos])
+			w.plaintext = grown
+			continue
 		}
 
 		nonce, err := generateSegmentNonce(w.nonceSize, w.noncePrefix, w.encryptedSegmentCnt, false)
@@ -257,6 +288,10 @@ type Reader struct {
 	ciphertext                   []byte
 	ciphertextPos                int
 	lastSegmentDecrypted         bool
+	// ciphertextBufferLimit is the full segment buffer size
+	// (CiphertextSegmentSize + 1 lookahead byte). r.ciphertext starts small
+	// and grows toward this limit only if bytes actually arrive.
+	ciphertextBufferLimit int
 }
 
 // ReaderParams contains the options for instantiating a Reader via NewReader().
@@ -302,8 +337,12 @@ func NewReader(params ReaderParams) (*Reader, error) {
 		noncePrefix:                  params.NoncePrefix,
 		firstCiphertextSegmentOffset: params.FirstCiphertextSegmentOffset,
 
-		// Allocate an extra byte to detect the last segment.
-		ciphertext: make([]byte, params.CiphertextSegmentSize+1),
+		// The buffer must be able to hold a full segment plus an extra byte
+		// to detect the last segment, but is allocated small and grown as
+		// bytes actually arrive, so that plaintexts much smaller than the
+		// segment size do not pay for a full segment-sized allocation.
+		ciphertext:            make([]byte, initialSegmentBufferSizeFor(params.CiphertextSegmentSize+1)),
+		ciphertextBufferLimit: params.CiphertextSegmentSize + 1,
 	}, nil
 }
 
@@ -321,11 +360,18 @@ func (r *Reader) Read(p []byte) (int, error) {
 	r.plaintext = r.plaintext[:0]
 	r.plaintextPos = 0
 
-	ctLim := len(r.ciphertext)
+	ctLim := r.ciphertextBufferLimit
 	if r.decryptedSegmentCnt == 0 {
 		ctLim -= r.firstCiphertextSegmentOffset
+		if ctLim > r.ciphertextBufferLimit {
+			// A negative FirstCiphertextSegmentOffset would require reading
+			// more bytes than the segment buffer can hold. The keyset-based
+			// streamingaead API never constructs such a Reader, but the
+			// exported subtle constructors only bound the offset from above.
+			return 0, ErrCiphertextSegmentTooShort
+		}
 	}
-	n, err := io.ReadFull(r.r, r.ciphertext[r.ciphertextPos:ctLim])
+	n, err := r.readSegmentGrowing(ctLim)
 	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
 		return 0, err
 	}
@@ -371,6 +417,119 @@ func (r *Reader) Read(p []byte) (int, error) {
 	n = copy(p, r.plaintext)
 	r.plaintextPos = n
 	return n, nil
+}
+
+// readSegmentGrowing reads into r.ciphertext[r.ciphertextPos:ctLim], growing
+// r.ciphertext toward the full segment buffer size as the stream proves to
+// have more data than the current buffer. ctLim must not exceed
+// r.ciphertextBufferLimit; Read guarantees this. It is semantically identical
+// to
+//
+//	io.ReadFull(r.r, r.ciphertext[r.ciphertextPos:ctLim])
+//
+// with a fully pre-allocated buffer: it returns the number of bytes read,
+// io.EOF if no bytes were read, and io.ErrUnexpectedEOF if the stream ended
+// after some bytes but before ctLim was reached. It issues one Read per
+// buffer growth step more than the pre-sized form (plus a one-byte probe
+// before each step), which only readers sensitive to request sizes or call
+// counts can observe.
+//
+// Throughout, end is the index one past the last buffered ciphertext byte,
+// and each read fills r.ciphertext[end:] up to ctLim or the current buffer
+// size, whichever is smaller. The loop and the error classification
+// otherwise mirror io.ReadAtLeast.
+func (r *Reader) readSegmentGrowing(ctLim int) (int, error) {
+	start := r.ciphertextPos
+	end := start
+	var err error
+	for end < ctLim && err == nil {
+		if end == len(r.ciphertext) {
+			// The buffer is full but the segment is not complete. Before
+			// growing, probe for a single further byte so that a stream
+			// that ends exactly at the buffer size does not pay for a
+			// larger buffer it will never fill.
+			var probe [1]byte
+			var m int
+			m, err = r.r.Read(probe[:])
+			if m == 0 {
+				continue
+			}
+			// Grow toward the full segment buffer size. Unlike the Writer,
+			// the Reader never knows how much data is still pending.
+			grown := make([]byte, grownSegmentBufferSize(len(r.ciphertext), 0, r.ciphertextBufferLimit))
+			copy(grown, r.ciphertext[:end])
+			grown[end] = probe[0]
+			end++
+			r.ciphertext = grown
+			continue
+		}
+		readLim := min(len(r.ciphertext), ctLim)
+		var m int
+		m, err = r.r.Read(r.ciphertext[end:readLim])
+		end += m
+	}
+	if end >= ctLim {
+		err = nil
+	} else if end > start && err == io.EOF {
+		err = io.ErrUnexpectedEOF
+	}
+	return end - start, err
+}
+
+// initialSegmentBufferSize is the initial allocation size for a segment
+// buffer. Segment buffers start small and grow (see grownSegmentBufferSize)
+// so that streams much smaller than the segment size do not pay for a
+// segment-sized allocation.
+const initialSegmentBufferSize = 4096
+
+// initialSegmentBufferSizeFor returns the initial allocation size for a
+// segment buffer with the given limit: initialSegmentBufferSize, unless the
+// full segment buffer is not much larger (or is smaller), in which case the
+// full size is allocated at once.
+func initialSegmentBufferSizeFor(limit int) int {
+	if initialSegmentBufferSize >= jumpThreshold(limit) {
+		return limit
+	}
+	return initialSegmentBufferSize
+}
+
+// jumpThreshold returns the size from which a growing segment buffer jumps
+// straight to limit: three quarters of it. The jump avoids a
+// nearly-full-sized step, such as one covering all but the Reader's one-byte
+// lookahead.
+func jumpThreshold(limit int) int {
+	return limit - limit/4
+}
+
+// grownSegmentBufferSize returns the next size for a segment buffer of size
+// cur that must grow toward limit: the next step of the sequence
+// initialSegmentBufferSize * growthFactor^k above cur, but no smaller than
+// needed, and limit itself once the chosen size would reach
+// jumpThreshold(limit).
+//
+// needed is the number of buffered and pending bytes already known to the
+// caller, or zero when unknown, so that a caller holding more data than a
+// growth step covers allocates for it in one step. Stepping along a fixed
+// sequence rather than multiplying cur keeps the total allocated over a
+// segment's growth independent of the sizes such callers ask for.
+func grownSegmentBufferSize(cur, needed, limit int) int {
+	const growthFactor = 8
+	threshold := jumpThreshold(limit)
+	stepped := initialSegmentBufferSize
+	for stepped <= cur {
+		// The multiplication is only taken when its result is below
+		// threshold, so it cannot overflow.
+		if stepped >= threshold/growthFactor {
+			stepped = limit
+			break
+		}
+		stepped *= growthFactor
+	}
+	newSize := max(stepped, needed)
+	if newSize >= threshold {
+		return limit
+	}
+	return newSize
 }
 
 // generateSegmentNonce returns a nonce for a segment.

--- a/streamingaead/subtle/noncebased/noncebased_internal_test.go
+++ b/streamingaead/subtle/noncebased/noncebased_internal_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noncebased
+
+import "testing"
+
+func TestGrownSegmentBufferSize(t *testing.T) {
+	const limit = 1 << 20
+	testcases := []struct {
+		cur, needed, limit, want int
+	}{
+		{cur: 4096, limit: limit, want: 32768},
+		{cur: 32768, limit: limit, want: 262144},
+		// A step from 262144 would reach 2 MiB, at least three quarters of
+		// the limit, so the size jumps to the limit instead.
+		{cur: 262144, limit: limit, want: limit},
+		// The exact threshold: (limit - limit/4) / 8 = 98304.
+		{cur: 98303, limit: limit, want: 786424},
+		{cur: 98304, limit: limit, want: limit},
+		// A limit one byte above a power of two (the Reader's lookahead
+		// byte) must not cost a full-sized step for that final byte.
+		{cur: 4096, limit: 4097, want: 4097},
+		{cur: 131072, limit: 1<<20 + 1, want: 1<<20 + 1},
+		// The growth step is a floor: pending data below it changes
+		// nothing.
+		{cur: 4096, needed: 10000, limit: limit, want: 32768},
+		// Pending data beyond the growth step is allocated in one step.
+		{cur: 4096, needed: 500000, limit: limit, want: 500000},
+		// Pending data at or beyond three quarters of the limit jumps to
+		// the limit, as a growth step would.
+		{cur: 4096, needed: 786432, limit: limit, want: limit},
+		{cur: 4096, needed: 786433, limit: limit, want: limit},
+		{cur: 4096, needed: 40 << 20, limit: limit, want: limit},
+	}
+	for _, tc := range testcases {
+		if got := grownSegmentBufferSize(tc.cur, tc.needed, tc.limit); got != tc.want {
+			t.Errorf("grownSegmentBufferSize(%d, %d, %d) = %d, want %d", tc.cur, tc.needed, tc.limit, got, tc.want)
+		}
+	}
+}

--- a/streamingaead/subtle/noncebased/noncebased_internal_test.go
+++ b/streamingaead/subtle/noncebased/noncebased_internal_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noncebased
+
+import "testing"
+
+func TestGrownSegmentBufferSize(t *testing.T) {
+	const limit = 1 << 20
+	testcases := []struct {
+		cur, needed, limit, want int
+	}{
+		{cur: 4096, limit: limit, want: 32768},
+		{cur: 32768, limit: limit, want: 262144},
+		// A step from 262144 would reach 2 MiB, at least three quarters of
+		// the limit, so the size jumps to the limit instead.
+		{cur: 262144, limit: limit, want: limit},
+		// Growth from a size off the fixed sequence (left by a needed
+		// floor) continues along the sequence.
+		{cur: 98303, limit: limit, want: 262144},
+		{cur: 262143, limit: limit, want: 262144},
+		{cur: 300000, limit: limit, want: limit},
+		// A limit one byte above a power of two (the Reader's lookahead
+		// byte) must not cost a full-sized step for that final byte.
+		{cur: 4096, limit: 4097, want: 4097},
+		{cur: 131072, limit: 1<<20 + 1, want: 262144},
+		{cur: 262144, limit: 1<<20 + 1, want: 1<<20 + 1},
+		// The growth step is a floor: pending data below it changes
+		// nothing.
+		{cur: 4096, needed: 10000, limit: limit, want: 32768},
+		// Pending data beyond the growth step is allocated in one step.
+		{cur: 4096, needed: 500000, limit: limit, want: 500000},
+		// Pending data at or beyond three quarters of the limit jumps to
+		// the limit, as a growth step would.
+		{cur: 4096, needed: 786432, limit: limit, want: limit},
+		{cur: 4096, needed: 786433, limit: limit, want: limit},
+		{cur: 4096, needed: 40 << 20, limit: limit, want: limit},
+	}
+	for _, tc := range testcases {
+		if got := grownSegmentBufferSize(tc.cur, tc.needed, tc.limit); got != tc.want {
+			t.Errorf("grownSegmentBufferSize(%d, %d, %d) = %d, want %d", tc.cur, tc.needed, tc.limit, got, tc.want)
+		}
+	}
+}
+
+func TestInitialSegmentBufferSizeFor(t *testing.T) {
+	testcases := []struct {
+		limit, want int
+	}{
+		{limit: 1, want: 1},
+		{limit: 4095, want: 4095},
+		{limit: 4096, want: 4096},
+		// A limit only slightly above the initial size (such as a 4 KiB
+		// ciphertext segment plus the lookahead byte) is allocated in full
+		// rather than grown by a single step.
+		{limit: 4097, want: 4097},
+		{limit: 5461, want: 5461},
+		{limit: 5462, want: 4096},
+		{limit: 1 << 20, want: 4096},
+	}
+	for _, tc := range testcases {
+		if got := initialSegmentBufferSizeFor(tc.limit); got != tc.want {
+			t.Errorf("initialSegmentBufferSizeFor(%d) = %d, want %d", tc.limit, got, tc.want)
+		}
+	}
+}
+
+// TestGrowthSequence checks that growth from the initial size always
+// progresses, never overshoots the limit, and takes a bounded number of
+// steps.
+func TestGrowthSequence(t *testing.T) {
+	for limit := 1; limit < 6000; limit++ {
+		cur := initialSegmentBufferSizeFor(limit)
+		for steps := 0; cur < limit; steps++ {
+			next := grownSegmentBufferSize(cur, 0, limit)
+			if next <= cur || next > limit {
+				t.Fatalf("limit=%d cur=%d: grownSegmentBufferSize = %d", limit, cur, next)
+			}
+			if steps > 4 {
+				t.Fatalf("limit=%d: too many growth steps", limit)
+			}
+			cur = next
+		}
+	}
+	limit := 1<<20 + 1
+	var sizes []int
+	for cur := initialSegmentBufferSizeFor(limit); ; cur = grownSegmentBufferSize(cur, 0, limit) {
+		sizes = append(sizes, cur)
+		if cur == limit {
+			break
+		}
+	}
+	want := []int{4096, 32768, 262144, limit}
+	if len(sizes) != len(want) {
+		t.Fatalf("growth sequence = %v, want %v", sizes, want)
+	}
+	for i := range want {
+		if sizes[i] != want[i] {
+			t.Fatalf("growth sequence = %v, want %v", sizes, want)
+		}
+	}
+}

--- a/streamingaead/subtle/noncebased/noncebased_test.go
+++ b/streamingaead/subtle/noncebased/noncebased_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"testing/iotest"
 
 	"github.com/tink-crypto/tink-go/v2/streamingaead/subtle/noncebased"
 )
@@ -542,5 +543,541 @@ func TestDecryptTruncatedCiphertext(t *testing.T) {
 			t.Errorf("io.ReadAll on ciphertext truncated at %d/%d bytes returned nil error; decrypted %d bytes of plaintext: %x (want error)",
 				i, len(ciphertext), len(got), got)
 		}
+	}
+}
+
+// TestReadWithSmallInitialBuffer exercises the lazily-allocated ciphertext
+// buffer in Reader. The buffer starts at a small initial size and grows
+// toward CiphertextSegmentSize+1 as segments prove larger than the current
+// allocation, so the interesting boundaries are ciphertext sizes and
+// ciphertext segment sizes just below, at, and just above the initial buffer
+// size (4096 bytes), and a segment large enough to walk the whole growth
+// sequence up to the jump to the full buffer size, including their
+// interaction with last-segment detection, the first-segment offset, and
+// readers that return data in small chunks.
+func TestReadWithSmallInitialBuffer(t *testing.T) {
+	// initialBufferSize must match initialSegmentBufferSize() in
+	// noncebased.go. The tests below probe ciphertext sizes around this
+	// boundary; if the constant changes, they still pass but no longer pin
+	// the boundary itself.
+	const initialBufferSize = 4096
+
+	const (
+		nonceSize       = 10
+		noncePrefixSize = 5
+	)
+	// With the test SegmentEncrypter a ciphertext segment is its plaintext
+	// segment plus nonceSize trailing bytes, so a single-segment ciphertext
+	// of size S corresponds to a plaintext of size S-nonceSize.
+	testcases := []struct {
+		name                         string
+		plaintextSize                int
+		plaintextSegmentSize         int
+		firstCiphertextSegmentOffset int
+		chunkSize                    int
+		oneByteReads                 bool
+		dataErrReads                 bool
+	}{
+		{
+			name:                 "singleSegmentCiphertextJustBelowInitialBuffer",
+			plaintextSize:        initialBufferSize - nonceSize - 1, // ciphertext: 4095 bytes
+			plaintextSegmentSize: 1 << 20,
+			chunkSize:            1000,
+		},
+		{
+			name:                 "singleSegmentCiphertextExactlyInitialBuffer",
+			plaintextSize:        initialBufferSize - nonceSize, // ciphertext: 4096 bytes
+			plaintextSegmentSize: 1 << 20,
+			chunkSize:            1000,
+		},
+		{
+			name:                 "singleSegmentCiphertextJustAboveInitialBuffer",
+			plaintextSize:        initialBufferSize - nonceSize + 1, // ciphertext: 4097 bytes
+			plaintextSegmentSize: 1 << 20,
+			chunkSize:            1000,
+		},
+		{
+			name:                 "singleSegmentCiphertextWellAboveInitialBuffer",
+			plaintextSize:        100000,
+			plaintextSegmentSize: 1 << 20,
+			chunkSize:            1000,
+		},
+		{
+			name:                 "emptyPlaintextLargeSegmentSize",
+			plaintextSize:        0,
+			plaintextSegmentSize: 1 << 20,
+			chunkSize:            1000,
+		},
+		{
+			// Ciphertext segments of exactly initialBufferSize-1: the buffer
+			// limit equals the initial size, so the buffer never grows and
+			// every non-final segment fills it completely.
+			name:                 "multiSegmentCiphertextSegmentJustBelowInitialBuffer",
+			plaintextSize:        3*(initialBufferSize-nonceSize-1) + 100,
+			plaintextSegmentSize: initialBufferSize - nonceSize - 1,
+			chunkSize:            1000,
+		},
+		{
+			// Ciphertext segments of exactly initialBufferSize: the buffer
+			// limit is initialBufferSize+1, so the very first segment grows
+			// the buffer by a single byte.
+			name:                 "multiSegmentCiphertextSegmentExactlyInitialBuffer",
+			plaintextSize:        3*(initialBufferSize-nonceSize) + 100,
+			plaintextSegmentSize: initialBufferSize - nonceSize,
+			chunkSize:            1000,
+		},
+		{
+			name:                 "multiSegmentCiphertextSegmentJustAboveInitialBuffer",
+			plaintextSize:        3*(initialBufferSize-nonceSize+1) + 100,
+			plaintextSegmentSize: initialBufferSize - nonceSize + 1,
+			chunkSize:            1000,
+		},
+		{
+			// A segment large enough that the buffer walks the whole growth
+			// sequence, ending with the jump to the full buffer size, and
+			// then completes segments in the fully-grown buffer.
+			name:                 "multiSegmentRequiringMultipleGrowthSteps",
+			plaintextSize:        1<<20 + 100,
+			plaintextSegmentSize: 1 << 20,
+			chunkSize:            1000,
+		},
+		{
+			// A plaintext that ends exactly at a segment boundary, so the
+			// last ciphertext segment is a full-sized segment.
+			name:                 "multiSegmentPlaintextAlignedWithSegmentSize",
+			plaintextSize:        2 * (initialBufferSize - nonceSize),
+			plaintextSegmentSize: initialBufferSize - nonceSize,
+			chunkSize:            1000,
+		},
+		{
+			name:                         "firstSegmentOffsetWithCiphertextAtInitialBuffer",
+			plaintextSize:                initialBufferSize - nonceSize,
+			plaintextSegmentSize:         1 << 20,
+			firstCiphertextSegmentOffset: 10,
+			chunkSize:                    1000,
+		},
+		{
+			name:                         "firstSegmentOffsetWithMultipleSegmentsAtInitialBuffer",
+			plaintextSize:                3*(initialBufferSize-nonceSize) + 100,
+			plaintextSegmentSize:         initialBufferSize - nonceSize,
+			firstCiphertextSegmentOffset: 10,
+			chunkSize:                    1000,
+		},
+		{
+			name:                 "oneByteReadsAcrossGrowBoundary",
+			plaintextSize:        initialBufferSize - nonceSize + 1,
+			plaintextSegmentSize: 1 << 20,
+			chunkSize:            1000,
+			oneByteReads:         true,
+		},
+		{
+			name:                 "oneByteReadsMultiSegment",
+			plaintextSize:        3*(initialBufferSize-nonceSize) + 100,
+			plaintextSegmentSize: initialBufferSize - nonceSize,
+			chunkSize:            7,
+			oneByteReads:         true,
+		},
+		{
+			// A reader that returns the final bytes together with io.EOF in
+			// a single call, at a ciphertext size where the final read ends
+			// mid-buffer.
+			name:                 "dataWithEOFAcrossGrowBoundary",
+			plaintextSize:        initialBufferSize - nonceSize + 1, // ciphertext: 4097 bytes
+			plaintextSegmentSize: 1 << 20,
+			chunkSize:            1000,
+			dataErrReads:         true,
+		},
+		{
+			// A reader that returns the final bytes together with io.EOF in
+			// a single call, at a ciphertext size where the final read ends
+			// exactly at a buffer boundary.
+			name:                 "dataWithEOFAtBufferBoundary",
+			plaintextSize:        initialBufferSize - nonceSize, // ciphertext: 4096 bytes
+			plaintextSegmentSize: 1 << 20,
+			chunkSize:            1000,
+			dataErrReads:         true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			writerParams := noncebased.WriterParams{
+				NonceSize:                    nonceSize,
+				PlaintextSegmentSize:         tc.plaintextSegmentSize,
+				FirstCiphertextSegmentOffset: tc.firstCiphertextSegmentOffset,
+			}
+			plaintext, ciphertext, noncePrefix, err := testEncrypt(tc.plaintextSize, noncePrefixSize, writerParams)
+			if err != nil {
+				t.Fatalf("encrypting failed: %v", err)
+			}
+
+			var r io.Reader = bytes.NewReader(ciphertext)
+			if tc.oneByteReads {
+				r = iotest.OneByteReader(r)
+			}
+			if tc.dataErrReads {
+				r = iotest.DataErrReader(r)
+			}
+			reader, err := noncebased.NewReader(noncebased.ReaderParams{
+				R:                            r,
+				SegmentDecrypter:             testDecrypterWithDst{},
+				NonceSize:                    nonceSize,
+				NoncePrefix:                  noncePrefix,
+				CiphertextSegmentSize:        tc.plaintextSegmentSize + nonceSize,
+				FirstCiphertextSegmentOffset: tc.firstCiphertextSegmentOffset,
+			})
+			if err != nil {
+				t.Fatalf("noncebased.NewReader() = _, err = %v, want nil", err)
+			}
+
+			var decrypted bytes.Buffer
+			chunk := make([]byte, tc.chunkSize)
+			for {
+				n, err := reader.Read(chunk)
+				decrypted.Write(chunk[:n])
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatalf("reader.Read() = _, err = %v, want nil", err)
+				}
+			}
+			if !bytes.Equal(decrypted.Bytes(), plaintext) {
+				t.Fatalf("decrypted data does not match plaintext. Got %d bytes, want %d bytes", decrypted.Len(), len(plaintext))
+			}
+		})
+	}
+}
+
+// TestReadTruncatedCiphertext pins Reader behavior for ciphertexts truncated
+// at boundaries around the initial buffer size: every case must behave
+// exactly as it did with the fully pre-allocated buffer.
+func TestReadTruncatedCiphertext(t *testing.T) {
+	const (
+		nonceSize       = 10
+		noncePrefixSize = 5
+	)
+	plaintextSegmentSize := 4096 - nonceSize
+	writerParams := noncebased.WriterParams{
+		NonceSize:            nonceSize,
+		PlaintextSegmentSize: plaintextSegmentSize,
+	}
+	_, ciphertext, noncePrefix, err := testEncrypt(3*plaintextSegmentSize+100, noncePrefixSize, writerParams)
+	if err != nil {
+		t.Fatalf("encrypting failed: %v", err)
+	}
+
+	testcases := []struct {
+		truncate     int
+		dataErrReads bool
+		wantErr      bool
+	}{
+		{truncate: 1, wantErr: true},
+		{truncate: 4095, wantErr: true},
+		{truncate: 4096, wantErr: true},
+		// Truncating to exactly one full non-final segment plus its 1-byte
+		// lookahead leaves that dangling byte to be decrypted as the final
+		// segment, which fails authentication.
+		{truncate: 4097, wantErr: true},
+		// The same boundary with a reader that returns the final byte
+		// together with io.EOF, so that the read which exactly fills the
+		// segment buffer also reports the end of the stream.
+		{truncate: 4097, dataErrReads: true, wantErr: true},
+		{truncate: len(ciphertext) - 1, wantErr: true},
+	}
+	for _, tc := range testcases {
+		name := fmt.Sprintf("truncatedAt%d", tc.truncate)
+		if tc.dataErrReads {
+			name += "DataErrReads"
+		}
+		t.Run(name, func(t *testing.T) {
+			var r io.Reader = bytes.NewReader(ciphertext[:tc.truncate])
+			if tc.dataErrReads {
+				r = iotest.DataErrReader(r)
+			}
+			reader, err := noncebased.NewReader(noncebased.ReaderParams{
+				R:                     r,
+				SegmentDecrypter:      testDecrypterWithDst{},
+				NonceSize:             nonceSize,
+				NoncePrefix:           noncePrefix,
+				CiphertextSegmentSize: plaintextSegmentSize + nonceSize,
+			})
+			if err != nil {
+				t.Fatalf("noncebased.NewReader() = _, err = %v, want nil", err)
+			}
+			_, err = io.ReadAll(reader)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("io.ReadAll() = _, err = %v, want error: %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestReadDegenerateFirstSegmentOffset verifies that a Reader constructed
+// with a FirstCiphertextSegmentOffset outside [0, CiphertextSegmentSize+1]
+// fails cleanly on the first Read. The keyset-based streamingaead API never
+// produces such offsets, but the exported subtle constructors only bound the
+// offset from above, so a negative offset can reach Read.
+func TestReadDegenerateFirstSegmentOffset(t *testing.T) {
+	const (
+		nonceSize             = 10
+		ciphertextSegmentSize = 100
+	)
+	for _, offset := range []int{-5, ciphertextSegmentSize + 2} {
+		t.Run(fmt.Sprintf("offset%d", offset), func(t *testing.T) {
+			reader, err := noncebased.NewReader(noncebased.ReaderParams{
+				R:                            bytes.NewReader(make([]byte, 50)),
+				SegmentDecrypter:             testDecrypterWithDst{},
+				NonceSize:                    nonceSize,
+				NoncePrefix:                  make([]byte, 5),
+				CiphertextSegmentSize:        ciphertextSegmentSize,
+				FirstCiphertextSegmentOffset: offset,
+			})
+			if err != nil {
+				t.Fatalf("noncebased.NewReader() = _, err = %v, want nil", err)
+			}
+			if _, err := reader.Read(make([]byte, 10)); err != noncebased.ErrCiphertextSegmentTooShort {
+				t.Fatalf("reader.Read() = _, err = %v, want ErrCiphertextSegmentTooShort", err)
+			}
+		})
+	}
+}
+
+// TestWriteWithSmallInitialBuffer exercises the lazily-allocated plaintext
+// buffer in Writer. The buffer starts at a small initial size and grows
+// toward PlaintextSegmentSize as the written data proves larger than the
+// current allocation, so the interesting boundaries are plaintext sizes and
+// plaintext segment sizes just below, at, and just above the initial buffer
+// size (4096 bytes), and a segment large enough to walk the whole growth
+// sequence up to the jump to the full segment size, including their
+// interaction with the first-segment offset and callers that write in small
+// chunks. Each case additionally
+// verifies that the produced ciphertext is byte-identical to one produced by
+// a single Write call of the whole plaintext: the write pattern must not
+// influence the output.
+func TestWriteWithSmallInitialBuffer(t *testing.T) {
+	// initialBufferSize must match initialSegmentBufferSize() in
+	// noncebased.go. The tests below probe plaintext sizes around this
+	// boundary; if the constant changes, they still pass but no longer pin
+	// the boundary itself.
+	const initialBufferSize = 4096
+
+	const (
+		nonceSize       = 10
+		noncePrefixSize = 5
+	)
+	testcases := []struct {
+		name                         string
+		plaintextSize                int
+		plaintextSegmentSize         int
+		firstCiphertextSegmentOffset int
+		writeChunkSize               int
+	}{
+		{
+			name:                 "singleSegmentPlaintextJustBelowInitialBuffer",
+			plaintextSize:        initialBufferSize - 1,
+			plaintextSegmentSize: 1 << 20,
+			writeChunkSize:       1000,
+		},
+		{
+			name:                 "singleSegmentPlaintextExactlyInitialBuffer",
+			plaintextSize:        initialBufferSize,
+			plaintextSegmentSize: 1 << 20,
+			writeChunkSize:       1000,
+		},
+		{
+			name:                 "singleSegmentPlaintextJustAboveInitialBuffer",
+			plaintextSize:        initialBufferSize + 1,
+			plaintextSegmentSize: 1 << 20,
+			writeChunkSize:       1000,
+		},
+		{
+			name:                 "singleSegmentPlaintextWellAboveInitialBuffer",
+			plaintextSize:        100000,
+			plaintextSegmentSize: 1 << 20,
+			writeChunkSize:       1000,
+		},
+		{
+			name:                 "emptyPlaintextLargeSegmentSize",
+			plaintextSize:        0,
+			plaintextSegmentSize: 1 << 20,
+			writeChunkSize:       1000,
+		},
+		{
+			// Plaintext segments one byte below the initial buffer size: the
+			// buffer limit is below the initial size, so the buffer starts at
+			// the limit and never grows.
+			name:                 "multiSegmentSegmentJustBelowInitialBuffer",
+			plaintextSize:        3*(initialBufferSize-1) + 100,
+			plaintextSegmentSize: initialBufferSize - 1,
+			writeChunkSize:       1000,
+		},
+		{
+			// Plaintext segments of exactly the initial buffer size: the
+			// buffer starts at the full segment size and never grows.
+			name:                 "multiSegmentSegmentExactlyInitialBuffer",
+			plaintextSize:        3*initialBufferSize + 100,
+			plaintextSegmentSize: initialBufferSize,
+			writeChunkSize:       1000,
+		},
+		{
+			// Plaintext segments one byte above the initial buffer size: the
+			// very first segment grows the buffer by a single byte.
+			name:                 "multiSegmentSegmentJustAboveInitialBuffer",
+			plaintextSize:        3*(initialBufferSize+1) + 100,
+			plaintextSegmentSize: initialBufferSize + 1,
+			writeChunkSize:       1000,
+		},
+		{
+			// A segment large enough that the buffer walks the whole growth
+			// sequence, ending with the jump to the full segment size, and
+			// then completes segments in the fully-grown buffer.
+			name:                 "multiSegmentRequiringMultipleGrowthSteps",
+			plaintextSize:        1<<20 + 100,
+			plaintextSegmentSize: 1 << 20,
+			writeChunkSize:       1000,
+		},
+		{
+			// A first Write large enough that the buffer is sized to the
+			// pending data exactly, followed by writes that grow it from
+			// that intermediate size and complete segments.
+			name:                 "largeFirstWriteThenGrowthFromOddSize",
+			plaintextSize:        1<<20 + 100,
+			plaintextSegmentSize: 1 << 20,
+			writeChunkSize:       500000,
+		},
+		{
+			// A plaintext that ends exactly at a segment boundary: Write
+			// defers the exactly-filled segment, and Close emits it as the
+			// last segment.
+			name:                 "multiSegmentPlaintextAlignedWithSegmentSize",
+			plaintextSize:        2 * initialBufferSize,
+			plaintextSegmentSize: initialBufferSize,
+			writeChunkSize:       1000,
+		},
+		{
+			// A single Write that fills the initial buffer exactly without
+			// completing a segment, followed directly by Close.
+			name:                 "singleWriteFillingInitialBufferThenClose",
+			plaintextSize:        initialBufferSize,
+			plaintextSegmentSize: 1 << 20,
+			writeChunkSize:       initialBufferSize,
+		},
+		{
+			name:                         "firstSegmentOffsetWithPlaintextAtInitialBuffer",
+			plaintextSize:                initialBufferSize,
+			plaintextSegmentSize:         1 << 20,
+			firstCiphertextSegmentOffset: 10,
+			writeChunkSize:               1000,
+		},
+		{
+			name:                         "firstSegmentOffsetWithMultipleSegmentsAtInitialBuffer",
+			plaintextSize:                3*initialBufferSize + 100,
+			plaintextSegmentSize:         initialBufferSize,
+			firstCiphertextSegmentOffset: 10,
+			writeChunkSize:               1000,
+		},
+		{
+			name:                 "oneByteWritesAcrossGrowBoundary",
+			plaintextSize:        initialBufferSize + 1,
+			plaintextSegmentSize: 1 << 20,
+			writeChunkSize:       1,
+		},
+		{
+			name:                 "oneByteWritesMultiSegment",
+			plaintextSize:        2*initialBufferSize + 50,
+			plaintextSegmentSize: initialBufferSize,
+			writeChunkSize:       1,
+		},
+	}
+
+	encryptChunked := func(t *testing.T, plaintext, noncePrefix []byte, segmentSize, offset, chunkSize int) []byte {
+		t.Helper()
+		var buf bytes.Buffer
+		w, err := noncebased.NewWriter(noncebased.WriterParams{
+			W:                            &buf,
+			SegmentEncrypter:             testEncrypterWithDst{},
+			NonceSize:                    nonceSize,
+			NoncePrefix:                  noncePrefix,
+			PlaintextSegmentSize:         segmentSize,
+			FirstCiphertextSegmentOffset: offset,
+		})
+		if err != nil {
+			t.Fatalf("noncebased.NewWriter() = _, err = %v, want nil", err)
+		}
+		for pos := 0; pos < len(plaintext); {
+			end := pos + chunkSize
+			if end > len(plaintext) {
+				end = len(plaintext)
+			}
+			n, err := w.Write(plaintext[pos:end])
+			if err != nil {
+				t.Fatalf("w.Write() = _, err = %v, want nil", err)
+			}
+			pos += n
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("w.Close() = err = %v, want nil", err)
+		}
+		return buf.Bytes()
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			plaintext := make([]byte, tc.plaintextSize)
+			if _, err := rand.Read(plaintext); err != nil {
+				t.Fatalf("rand.Read() = _, err = %v, want nil", err)
+			}
+			noncePrefix := make([]byte, noncePrefixSize)
+			if _, err := rand.Read(noncePrefix); err != nil {
+				t.Fatalf("rand.Read() = _, err = %v, want nil", err)
+			}
+
+			ciphertext := encryptChunked(t, plaintext, noncePrefix, tc.plaintextSegmentSize, tc.firstCiphertextSegmentOffset, tc.writeChunkSize)
+			singleWrite := encryptChunked(t, plaintext, noncePrefix, tc.plaintextSegmentSize, tc.firstCiphertextSegmentOffset, tc.plaintextSize+1)
+			if !bytes.Equal(ciphertext, singleWrite) {
+				t.Fatalf("chunked writes produced a different ciphertext than a single write. Got %d bytes, want %d bytes", len(ciphertext), len(singleWrite))
+			}
+
+			readerParams := noncebased.ReaderParams{
+				NonceSize:                    nonceSize,
+				NoncePrefix:                  noncePrefix,
+				CiphertextSegmentSize:        tc.plaintextSegmentSize + nonceSize,
+				FirstCiphertextSegmentOffset: tc.firstCiphertextSegmentOffset,
+			}
+			if err := testDecrypt(plaintext, ciphertext, 1000, readerParams); err != nil {
+				t.Fatalf("decrypting failed: %v", err)
+			}
+		})
+	}
+}
+
+// TestWriteDegenerateFirstSegmentOffset verifies that a Writer constructed
+// with a FirstCiphertextSegmentOffset outside [0, PlaintextSegmentSize] fails
+// cleanly on the first Write. The keyset-based streamingaead API never
+// produces such offsets, but the exported subtle constructors only bound the
+// offset from above, so a negative offset can reach Write.
+func TestWriteDegenerateFirstSegmentOffset(t *testing.T) {
+	const (
+		nonceSize            = 10
+		plaintextSegmentSize = 100
+	)
+	for _, offset := range []int{-5, plaintextSegmentSize + 1} {
+		t.Run(fmt.Sprintf("offset%d", offset), func(t *testing.T) {
+			w, err := noncebased.NewWriter(noncebased.WriterParams{
+				W:                            &bytes.Buffer{},
+				SegmentEncrypter:             testEncrypterWithDst{},
+				NonceSize:                    nonceSize,
+				NoncePrefix:                  make([]byte, 5),
+				PlaintextSegmentSize:         plaintextSegmentSize,
+				FirstCiphertextSegmentOffset: offset,
+			})
+			if err != nil {
+				t.Fatalf("noncebased.NewWriter() = _, err = %v, want nil", err)
+			}
+			if _, err := w.Write(make([]byte, 50)); err == nil {
+				t.Fatal("w.Write() = _, err = nil, want error")
+			}
+		})
 	}
 }


### PR DESCRIPTION
`noncebased.NewReader` and `noncebased.NewWriter` eagerly allocate segment-sized buffers: the Reader a ciphertext buffer of `CiphertextSegmentSize+1` bytes, the Writer a plaintext buffer of `PlaintextSegmentSize` bytes. With the 1MB key templates that is a ~1 MiB allocation per primitive regardless of how much data the stream carries, and the decrypting primitive constructs one reader per candidate key in the keyset. Workloads that process many small records — for example, envelope encryption of few-hundred-byte records — pay ~1 MiB of allocation, zeroing, and GC pressure per record on each side, several orders of magnitude more than the data they process.

This change makes both buffers start at 4 KiB (or the full size, when that is smaller) and grow on demand:

- Growth multiplies the buffer by 8, and jumps directly to the full size once a step would reach at least three quarters of it. Plain doubling was measured and rejected: cumulative doubling costs segment-sized streams roughly twice their size in extra allocation, and its power-of-two sequence lands on exactly the segment size only to reallocate once more for the Reader's one-byte lookahead.
- The Writer additionally never grows smaller than the buffered data plus what remains of the current `Write` call, so a caller handing over a large record in one call allocates exactly as the eager code did.
- Growth state is per-primitive, not per-segment: a large stream walks the sequence once during its first segment and then reuses the full-size buffer.

The wire format and ciphertext bytes are unchanged — tests assert that chunked writes produce ciphertext byte-identical to a single write. With 300-byte payloads and the 1MB templates, decryption drops from ~97–111 µs and ~1 MB/op to ~6–7.5 µs and ~8 KB/op, and encryption similarly; 16 MiB streams are unchanged within noise (+9 allocs/op, ~12% B/op from the one-time growth sequence). Payloads between 4 KiB and the segment size now allocate roughly in proportion to their size. Full numbers are in the commit message.

One behavioral edge changes in the direction of failing cleanly: a Reader or Writer whose `FirstCiphertextSegmentOffset` lies outside the valid range previously panicked with a slice-bounds error on first use and now returns an error. Such offsets are not produced by the keyset-based API, but the exported subtle constructors only bound the offset from above, so a negative offset could previously reach the panic.
