### PR TITLE
keyset: only an enabled key may become the primary

### DIFF
--- a/keyset/handle.go
+++ b/keyset/handle.go
@@ -217,12 +217,6 @@ func newFromEntries(entries []*Entry, opts ...Option) (*Handle, error) {
 	var primaryKeyEntry *Entry = nil
 	for _, entry := range entries {
 		if entry.IsPrimary() {
-			// Callers other than keysetToEntries construct entries directly, so
-			// fail closed rather than let a non-enabled key be used to sign or
-			// encrypt new data.
-			if entry.KeyStatus() != Enabled {
-				return nil, fmt.Errorf("keyset.Handle: primary key must be enabled")
-			}
 			primaryKeyEntry = entry
 		}
 		if entry.KeyStatus() == Unknown {

--- a/keyset/handle.go
+++ b/keyset/handle.go
@@ -216,11 +216,13 @@ func setEntryMonitoringIfNeeded(h *Handle) error {
 func newFromEntries(entries []*Entry, opts ...Option) (*Handle, error) {
 	var primaryKeyEntry *Entry = nil
 	for _, entry := range entries {
-		// A keyset may contain more than one entry whose key ID equals the
-		// primary key ID, so more than one entry here can report IsPrimary.
-		// Only an enabled key may become the primary: otherwise a disabled or
-		// destroyed key could end up being used to sign or encrypt new data.
-		if entry.IsPrimary() && entry.KeyStatus() == Enabled {
+		if entry.IsPrimary() {
+			// Callers other than keysetToEntries construct entries directly, so
+			// fail closed rather than let a non-enabled key be used to sign or
+			// encrypt new data.
+			if entry.KeyStatus() != Enabled {
+				return nil, fmt.Errorf("keyset.Handle: primary key must be enabled")
+			}
 			primaryKeyEntry = entry
 		}
 		if entry.KeyStatus() == Unknown {
@@ -278,7 +280,12 @@ func keysetToEntries(ks *tinkpb.Keyset) ([]*Entry, error) {
 		if err != nil {
 			return nil, err
 		}
-		entries[i] = newUnmonitoredEntry(key, protoKey.GetKeyId() == ks.GetPrimaryKeyId(), protoKey.GetKeyId(), keyStatus)
+		// A key is the primary only if it is both designated by primary_key_id
+		// and enabled. Keysets may repeat key IDs, so without the status check
+		// a disabled or destroyed duplicate of the primary would also be
+		// marked primary.
+		isPrimary := protoKey.GetKeyId() == ks.GetPrimaryKeyId() && keyStatus == Enabled
+		entries[i] = newUnmonitoredEntry(key, isPrimary, protoKey.GetKeyId(), keyStatus)
 	}
 	return entries, nil
 }

--- a/keyset/handle.go
+++ b/keyset/handle.go
@@ -216,7 +216,11 @@ func setEntryMonitoringIfNeeded(h *Handle) error {
 func newFromEntries(entries []*Entry, opts ...Option) (*Handle, error) {
 	var primaryKeyEntry *Entry = nil
 	for _, entry := range entries {
-		if entry.IsPrimary() {
+		// A keyset may contain more than one entry whose key ID equals the
+		// primary key ID, so more than one entry here can report IsPrimary.
+		// Only an enabled key may become the primary: otherwise a disabled or
+		// destroyed key could end up being used to sign or encrypt new data.
+		if entry.IsPrimary() && entry.KeyStatus() == Enabled {
 			primaryKeyEntry = entry
 		}
 		if entry.KeyStatus() == Unknown {

--- a/keyset/handle_test.go
+++ b/keyset/handle_test.go
@@ -1613,6 +1613,8 @@ func TestNewHandleWithDuplicatePrimaryKeyIDSelectsEnabledKey(t *testing.T) {
 					},
 				},
 			}
+			// testkeyset.NewHandle eventually calls keysetToEntries, which is
+			// where isPrimary is assigned from the key ID and the status.
 			handle, err := testkeyset.NewHandle(ks)
 			if err != nil {
 				t.Fatalf("testkeyset.NewHandle(ks) err = %v, want nil", err)
@@ -1623,6 +1625,22 @@ func TestNewHandleWithDuplicatePrimaryKeyIDSelectsEnabledKey(t *testing.T) {
 			}
 			if got, want := primary.KeyStatus(), keyset.Enabled; got != want {
 				t.Errorf("handle.Primary().KeyStatus() = %v, want %v", got, want)
+			}
+			// The non-enabled duplicate shares the primary key ID, so it must
+			// not report itself as primary either.
+			if handle.Len() != 2 {
+				t.Fatalf("handle.Len() = %d, want 2", handle.Len())
+			}
+			for i := 0; i < handle.Len(); i++ {
+				entry, err := handle.Entry(i)
+				if err != nil {
+					t.Fatalf("handle.Entry(%d) err = %v, want nil", i, err)
+				}
+				want := entry.KeyStatus() == keyset.Enabled
+				if got := entry.IsPrimary(); got != want {
+					t.Errorf("handle.Entry(%d).IsPrimary() = %v, want %v (status %v)",
+						i, got, want, entry.KeyStatus())
+				}
 			}
 		})
 	}

--- a/keyset/handle_test.go
+++ b/keyset/handle_test.go
@@ -1579,3 +1579,51 @@ func TestWriteGeneratesNoKeyExport(t *testing.T) {
 		t.Errorf("fakeClient.KeyExportsLogs() = %v, want nil", fakeClient.KeyExportsLogs())
 	}
 }
+
+// Tink allows keysets in which key IDs are repeated. When a repeated ID is also
+// the primary key ID, several entries report IsPrimary, and only an enabled one
+// may be selected: otherwise a disabled or destroyed key would be used to sign
+// and encrypt new data.
+func TestNewHandleWithDuplicatePrimaryKeyIDSelectsEnabledKey(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status tinkpb.KeyStatusType
+	}{
+		{name: "disabled duplicate", status: tinkpb.KeyStatusType_DISABLED},
+		{name: "destroyed duplicate", status: tinkpb.KeyStatusType_DESTROYED},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Both keys have ID 1, which is also the primary key ID. The
+			// enabled key comes first so that the non-enabled duplicate is the
+			// last entry reporting IsPrimary.
+			ks := &tinkpb.Keyset{
+				PrimaryKeyId: 1,
+				Key: []*tinkpb.Keyset_Key{
+					&tinkpb.Keyset_Key{
+						KeyId:            1,
+						Status:           tinkpb.KeyStatusType_ENABLED,
+						OutputPrefixType: tinkpb.OutputPrefixType_TINK,
+						KeyData:          testutil.NewKeyData("some type url", []byte{0}, tinkpb.KeyData_SYMMETRIC),
+					},
+					&tinkpb.Keyset_Key{
+						KeyId:            1,
+						Status:           tc.status,
+						OutputPrefixType: tinkpb.OutputPrefixType_TINK,
+						KeyData:          testutil.NewKeyData("some type url", []byte{0}, tinkpb.KeyData_SYMMETRIC),
+					},
+				},
+			}
+			handle, err := testkeyset.NewHandle(ks)
+			if err != nil {
+				t.Fatalf("testkeyset.NewHandle(ks) err = %v, want nil", err)
+			}
+			primary, err := handle.Primary()
+			if err != nil {
+				t.Fatalf("handle.Primary() err = %v, want nil", err)
+			}
+			if got, want := primary.KeyStatus(), keyset.Enabled; got != want {
+				t.Errorf("handle.Primary().KeyStatus() = %v, want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`newFromEntries` selects the primary entry with:

```go
if entry.IsPrimary() {
    primaryKeyEntry = entry
}
```

`IsPrimary` is set purely on ID equality — `keysetToEntries` passes
`protoKey.GetKeyId() == ks.GetPrimaryKeyId()` (keyset/handle.go:277) with no
status coupling. Tink permits keysets in which key IDs are repeated, so when a
repeated ID is also the primary key ID, several entries report `IsPrimary` and
the loop keeps the **last** one, whatever its status. The only status test in
the loop rejects `Unknown`; `Disabled` and `Destroyed` pass.

`Validate` does not prevent this, because it skips non-enabled keys
(keyset/validation.go:49-50) before reaching the primary-key accounting, so the
non-enabled duplicate is never counted and "keyset contains multiple primary
keys" does not fire.

The result is that `Handle.Primary()` can return a key the keyset marks as
disabled or destroyed. Every factory that produces new output takes the primary
without re-checking its status — `signature/signer_factory.go:39`,
`jwt/jwt_signer_factory.go:42`, `hybrid/hybrid_encrypt_factory.go:55`, and the
aead, daead, streamingaead and mac factories — so a key that was taken out of
service is still used to sign and encrypt new data.

### Reproducing

Keyset with `primary_key_id: 1` and two entries both with key ID 1, the enabled
one first:

| entry | key ID | status |
|---|---|---|
| 0 | 1 | ENABLED |
| 1 | 1 | DISABLED |

`Validate` accepts it, and before this change `handle.Primary().KeyStatus()`
returns `Disabled`. The added test covers both the `DISABLED` and `DESTROYED`
duplicate and fails on the current code with:

```
handle_test.go:1625: handle.Primary().KeyStatus() = Disabled, want Enabled
handle_test.go:1625: handle.Primary().KeyStatus() = Destroyed, want Enabled
```

Only the ordering `[ENABLED, DISABLED]` is affected; with the non-enabled
duplicate first, last-wins happens to land on the enabled key.

### Comparison with the other implementations

Both tink-cc and tink-java already prevent this, which is what suggests the Go
behaviour is unintended rather than deliberate:

- **tink-cc** — `KeysetHandle::Validate` counts every key matching
  `primary_key_id` regardless of status and rejects a non-enabled primary
  ("Keyset has primary that is not enabled"), as well as `num_primary > 1`.
  `GetPrimary()` runs it first.
- **tink-java** — `KeysetHandle.getPrimary()` returns the *first* entry
  reporting `isPrimary` and throws `IllegalStateException("Keyset has primary
  which isn't enabled")` when its status is not `ENABLED`.

### The change

`newFromEntries` now requires an entry to be enabled before it can be selected
as the primary.

This is deliberately narrower than the C++ rule. Mirroring tink-cc exactly —
rejecting any keyset with more than one entry matching the primary key ID —
would also reject repeated-ID keysets that Tink currently supports, so this
change only constrains which entry may be chosen and leaves keyset acceptance
unchanged.

It cannot introduce a spurious "no primary key" error on any existing path:

- `newKeysetHandleFromProto` runs `Validate` first, which only sets
  `hasPrimaryKey` for an ENABLED key matching the primary ID, so an enabled
  candidate is guaranteed to exist.
- `Manager.Handle()` builds from entries whose primary was set by `SetPrimary`,
  which refuses a non-enabled key (keyset/manager.go:275-277); `Disable` and
  `Delete` both refuse the primary.
- `Handle.Public()` copies status and primary flags from a handle that already
  passed this constructor.

An alternative would be to fix `Validate` so the primary-key accounting runs
before the non-enabled skip; happy to switch to that shape, or to reject the
ambiguous keyset outright, if either is preferred.

`go build ./...` and `go test ./...` pass on this branch.
