### PR TITLE
Add duplicate key_id validation to keyset.Validate()

### DIFF
--- a/keyset/validation.go
+++ b/keyset/validation.go
@@ -42,7 +42,13 @@ func Validate(keyset *tinkpb.Keyset) error {
 	primaryKeyID := keyset.PrimaryKeyId
 	hasPrimaryKey := false
 	numEnabledKeys := 0
+	seenKeyIDs := make(map[uint32]struct{})
 	for _, key := range keyset.Key {
+		if _, exists := seenKeyIDs[key.KeyId]; exists {
+			return fmt.Errorf("keyset contains duplicate key_id: %d", key.KeyId)
+		}
+		seenKeyIDs[key.KeyId] = struct{}{}
+
 		if err := validateKey(key); err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently keyset.Validate() accepts keysets with duplicate key_ids.
Two keys with the same key_id produce identical 5-byte output prefixes,
causing key confusion in the PrefixMap (first-match-wins during
decrypt/verify).

Adds a `seenKeyIDs` set that rejects duplicates at deserialization time.
Uses map[uint32]struct{} for zero-alloc set semantics.